### PR TITLE
Launcher fixup

### DIFF
--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -88,9 +88,14 @@ init_global_variables() {
   CHE_LOCAL_BINARY_ARGS=${CHE_LOCAL_BINARY:+-v "${CHE_LOCAL_BINARY}":/home/user/che}
 
   # CHE_STORAGE_ARGS is where Che JSON files and workspace / project files are saved
-  CHE_STORAGE_ARGS=${CHE_DATA_FOLDER:+-v "${CHE_DATA_FOLDER}"/storage:/home/user/che/storage \
-                                      -e CHE_WORKSPACE_STORAGE="${CHE_DATA_FOLDER}"/workspaces \
-                                      -e CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false}
+  if is_docker_for_mac || is_docker_for_windows; then
+    CHE_STORAGE_ARGS=${CHE_DATA_FOLDER:+-v "${CHE_DATA_FOLDER}/storage":/home/user/che/storage \
+                                        -e "CHE_WORKSPACE_STORAGE=${CHE_DATA_FOLDER}/workspaces" \
+                                        -e "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false"}
+  else
+    CHE_STORAGE_ARGS=${CHE_DATA_FOLDER:+-v "${CHE_DATA_FOLDER}/storage":/home/user/che/storage \
+                                        -v "${CHE_DATA_FOLDER}/workspaces":/home/user/che/workspaces}
+  fi
 
   if [ "${CHE_LOG_LEVEL}" = "debug" ]; then
     CHE_DEBUG_OPTION="--debug --log_level:debug"

--- a/che-mount/sync.sh
+++ b/che-mount/sync.sh
@@ -67,17 +67,7 @@ init_logging
 init_global_variables
 parse_command_line "$@"
 
-ssh-keygen -b 2048 -t rsa -f ~/id_rsa -q -N ""
-rsync -aq --rsync-path="mkir -p ~/.ssh && rsync" \
-      -e "ssh -p $2" \
-      ~/id_rsa.pub \
-      user@10.075.2:~/ssh/authorized_keys
-
-# On the workspace palce the public key /home/user/.ssh/authorized_keys
-#Do an append the additional key
-#Private key goes in mount cntainer ~/.ssh/id_rsa
-
-sshfs user@$1:/projects /mntssh -p $2 -o IdentityFile=~/id_rsa
+sshfs user@$1:/projects /mntssh -p $2
 unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer > /dev/null 2>&1
 
 info "INFO: ECLIPSE CHE: Successfully mounted user@$1:/projects"

--- a/che-mount/sync.sh
+++ b/che-mount/sync.sh
@@ -67,7 +67,17 @@ init_logging
 init_global_variables
 parse_command_line "$@"
 
-sshfs user@$1:/projects /mntssh -p $2
+ssh-keygen -b 2048 -t rsa -f ~/id_rsa -q -N ""
+rsync -aq --rsync-path="mkir -p ~/.ssh && rsync" \
+      -e "ssh -p $2" \
+      ~/id_rsa.pub \
+      user@10.075.2:~/ssh/authorized_keys
+
+# On the workspace palce the public key /home/user/.ssh/authorized_keys
+#Do an append the additional key
+#Private key goes in mount cntainer ~/.ssh/id_rsa
+
+sshfs user@$1:/projects /mntssh -p $2 -o IdentityFile=~/id_rsa
 unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer > /dev/null 2>&1
 
 info "INFO: ECLIPSE CHE: Successfully mounted user@$1:/projects"


### PR DESCRIPTION
Fixes issue where launcher on boot2docker or other windows systems needs to use different syntax for volume mounting the storage location of a workspace.