### PR TITLE
Add che-launcher support for windows paths with spaces and dots

### DIFF
--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -79,23 +79,10 @@ init_global_variables() {
   CHE_LOG_LEVEL=${CHE_LOG_LEVEL:-${DEFAULT_CHE_LOG_LEVEL}}
   CHE_DATA_FOLDER=${CHE_DATA_FOLDER:-${DEFAULT_CHE_DATA_FOLDER}}
 
-  # CHE_CONF_ARGS are the Docker run options that need to be used if users set CHE_CONF_FOLDER:
-  #   - empty if CHE_CONF_FOLDER is not set
-  #   - -v ${CHE_CONF_FOLDER}:/conf -e "CHE_LOCAL_CONF_DIR=/conf" if CHE_CONF_FOLDER is set
-  CHE_CONF_ARGS=${CHE_CONF_FOLDER:+-v "${CHE_CONF_FOLDER}":/conf -e "CHE_LOCAL_CONF_DIR=/conf"}
-
-  # CHE_LOCAL_BINARY is the path to a Che assembly that will be mounted into the Che server container
-  CHE_LOCAL_BINARY_ARGS=${CHE_LOCAL_BINARY:+-v "${CHE_LOCAL_BINARY}":/home/user/che}
-
-  # CHE_STORAGE_ARGS is where Che JSON files and workspace / project files are saved
-  if is_docker_for_mac || is_docker_for_windows; then
-    CHE_STORAGE_ARGS=${CHE_DATA_FOLDER:+-v "${CHE_DATA_FOLDER}/storage":/home/user/che/storage \
-                                        -e "CHE_WORKSPACE_STORAGE=${CHE_DATA_FOLDER}/workspaces" \
-                                        -e "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false"}
-  else
-    CHE_STORAGE_ARGS=${CHE_DATA_FOLDER:+-v "${CHE_DATA_FOLDER}/storage":/home/user/che/storage \
-                                        -v "${CHE_DATA_FOLDER}/workspaces":/home/user/che/workspaces}
-  fi
+  CHE_CONF_LOCATION="${CHE_CONF_FOLDER}":"/conf" 
+  CHE_STORAGE_LOCATION="$CHE_DATA_FOLDER/storage":"/home/user/che/storage"
+  CHE_WORKSPACE_LOCATION="$CHE_DATA_FOLDER/workspaces":"/home/user/che/workspaces"
+  CHE_LOCAL_BINARY_LOCATION="$CHE_LOCAL_BINARY":"/home/user/che"
 
   if [ "${CHE_LOG_LEVEL}" = "debug" ]; then
     CHE_DEBUG_OPTION="--debug --log_level:debug"

--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -80,9 +80,9 @@ init_global_variables() {
   CHE_DATA_FOLDER=${CHE_DATA_FOLDER:-${DEFAULT_CHE_DATA_FOLDER}}
 
   CHE_CONF_LOCATION="${CHE_CONF_FOLDER}":"/conf" 
-  CHE_STORAGE_LOCATION="$CHE_DATA_FOLDER/storage":"/home/user/che/storage"
-  CHE_WORKSPACE_LOCATION="$CHE_DATA_FOLDER/workspaces":"/home/user/che/workspaces"
-  CHE_LOCAL_BINARY_LOCATION="$CHE_LOCAL_BINARY":"/home/user/che"
+  CHE_STORAGE_LOCATION="${CHE_DATA_FOLDER}/storage":"/home/user/che/storage"
+  CHE_WORKSPACE_LOCATION="${CHE_DATA_FOLDER}/workspaces":"/home/user/che/workspaces"
+  CHE_LOCAL_BINARY_LOCATION="${CHE_LOCAL_BINARY}":"/home/user/che"
 
   if [ "${CHE_LOG_LEVEL}" = "debug" ]; then
     CHE_DEBUG_OPTION="--debug --log_level:debug"

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -23,7 +23,7 @@ start_che_server() {
   CURRENT_IMAGE=$(docker images -q "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}")
 
   if [ "${CURRENT_IMAGE}" != "" ]; then
-    info "${CHE_PRODUCT_NAME}: Already have image ${CHE_SERVER_IMAGE_NAME}:${CHE_VERSION}"
+    info "${CHE_PRODUCT_NAME}: Found image ${CHE_SERVER_IMAGE_NAME}:${CHE_VERSION}"
   else
     update_che_server
   fi

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -28,28 +28,14 @@ start_che_server() {
     update_che_server
   fi
 
-  ENV_FILE=$(get_list_of_che_system_environment_variables)
-
   info "${CHE_PRODUCT_NAME}: Starting container..."
-  docker run -d --name "${CHE_SERVER_CONTAINER_NAME}" \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v /home/user/che/lib:/home/user/che/lib-copy \
-    ${CHE_LOCAL_BINARY_ARGS} \
-    -p "${CHE_PORT}":8080 \
-    --restart="${CHE_RESTART_POLICY}" \
-    --user="${CHE_USER}" \
-    ${CHE_CONF_ARGS} \
-    ${CHE_STORAGE_ARGS} \
-    --env-file=$ENV_FILE \
-    "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" \
-                --remote:"${CHE_HOST_IP}" \
-                -s:uid \
-                -s:client \
-                ${CHE_DEBUG_OPTION} \
-                run > /dev/null
+  docker_run_with_conf "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" \
+                          --remote:"${CHE_HOST_IP}" \
+                          -s:uid \
+                          -s:client \
+                          ${CHE_DEBUG_OPTION} \
+                          run > /dev/null
 
-  rm $ENV_FILE
-  
   wait_until_container_is_running 10
   if ! che_container_is_running; then
     error_exit "${CHE_PRODUCT_NAME}: Timeout waiting for ${CHE_PRODUCT_NAME} container to start."

--- a/che-launcher/launcher_funcs.sh
+++ b/che-launcher/launcher_funcs.sh
@@ -104,7 +104,6 @@ is_docker_for_windows() {
 }
 
 docker_run() {
-  echo "here"
    ENV_FILE=$(get_list_of_che_system_environment_variables)
    docker run -d --name "${CHE_SERVER_CONTAINER_NAME}" \
     -v /var/run/docker.sock:/var/run/docker.sock \
@@ -119,11 +118,10 @@ docker_run() {
 }
 
 docker_run_with_storage() {
-  echo "here"
   if is_docker_for_mac || is_docker_for_windows; then
     # If on docker for mac or windows, then we have to use these special parameters
     docker_run -e "CHE_WORKSPACE_STORAGE=$CHE_DATA_FOLDER/workspaces" \
-                            -e "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false" "$@"
+               -e "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false" "$@"
   else
     # Otherwise, mount the full directory
     docker_run -v "$CHE_WORKSPACE_LOCATION" "$@"
@@ -131,7 +129,6 @@ docker_run_with_storage() {
 }
 
 docker_run_with_local_binary() {
-  echo "here"
   if has_local_binary_path; then
     docker_run_with_storage -v "$CHE_LOCAL_BINARY_LOCATION" "$@"
   else
@@ -140,7 +137,6 @@ docker_run_with_local_binary() {
 }
 
 docker_run_with_conf() {
-  echo "here"
   if has_che_conf_path; then
     docker_run_with_local_binary -v "$CHE_CONF_LOCATION" -e "CHE_LOCAL_CONF_DIR=/conf" "$@"
   else

--- a/che-launcher/launcher_funcs.sh
+++ b/che-launcher/launcher_funcs.sh
@@ -103,6 +103,67 @@ is_docker_for_windows() {
   fi
 }
 
+docker_run() {
+  echo "here"
+   ENV_FILE=$(get_list_of_che_system_environment_variables)
+   docker run -d --name "${CHE_SERVER_CONTAINER_NAME}" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /home/user/che/lib:/home/user/che/lib-copy \
+    -p "${CHE_PORT}":8080 \
+    --restart="${CHE_RESTART_POLICY}" \
+    --user="${CHE_USER}" \
+    --env-file=$ENV_FILE \
+    -v "$CHE_STORAGE_LOCATION" "$@"
+ 
+   rm -rf $ENV_FILE > /dev/null
+}
+
+docker_run_with_storage() {
+  echo "here"
+  if is_docker_for_mac || is_docker_for_windows; then
+    # If on docker for mac or windows, then we have to use these special parameters
+    docker_run -e "CHE_WORKSPACE_STORAGE=$CHE_DATA_FOLDER/workspaces" \
+                            -e "CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false" "$@"
+  else
+    # Otherwise, mount the full directory
+    docker_run -v "$CHE_WORKSPACE_LOCATION" "$@"
+  fi
+}
+
+docker_run_with_local_binary() {
+  echo "here"
+  if has_local_binary_path; then
+    docker_run_with_storage -v "$CHE_LOCAL_BINARY_LOCATION" "$@"
+  else
+    docker_run_with_storage "$@"
+  fi
+}
+
+docker_run_with_conf() {
+  echo "here"
+  if has_che_conf_path; then
+    docker_run_with_local_binary -v "$CHE_CONF_LOCATION" -e "CHE_LOCAL_CONF_DIR=/conf" "$@"
+  else
+    docker_run_with_local_binary "$@"
+  fi
+}
+
+has_che_conf_path() {
+  if [ "${CHE_CONF_FOLDER}" = "" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+has_local_binary_path() {
+  if [ "${CHE_LOCAL_BINARY}" = "" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 get_list_of_che_system_environment_variables() {
   # See: http://stackoverflow.com/questions/4128235/what-is-the-exact-meaning-of-ifs-n
   IFS=$'\n'
@@ -114,6 +175,7 @@ get_list_of_che_system_environment_variables() {
   for SINGLE_VARIABLE in "${CHE_VARIABLES}"; do
     echo "${SINGLE_VARIABLE}" >> $DOCKER_ENV
   done
+  
 
   # Add in known proxy variables
   if [ ! -z ${http_proxy+x} ]; then 


### PR DESCRIPTION
Fixes issues within the che-launcher to able to accept Windows paths that have spaces and dots in their name when users set `CHE_LOCAL_BINARY`, `CHE_DATA_FOLDER`, or `CHE_CONF_FOLDER`. Also separates the big docker run command into a bunch of layered commands where logic can be added for each variable passed along.

@l0rd - note, had to break up some of the logic that you were using to be able to wrap certain folders in quotes without the `-v` also being in quotes. This seems to be the only way to work around limitations in docker.

TESTED ON:
1. Windows 10 Home with boot2docker
2. Windows 10 Professional with Docker for Windows
3. Mac OSx - Docker for Windows Beta
4. Ubuntu 16.04 @ digital ocean

Test configuration for windows:
```
TEST="c:\Users\Valued Customer"
TEST_CONF="c:\Users\Valued Customer\test.path"
TESTER=$(get_mount_path "$TEST")
TESTER_CONF=$(get_mount_path "$TEST_CONF")

docker rm -f che-server > /dev/null

MSYS_NO_PATHCONV=1 docker run -it -v /var/run/docker.sock:/var/run/docker.sock \
  --env "CHE_CONF_FOLDER=$TESTER_CONF" \
  --env "CHE_DATA_FOLDER=$TESTER" \
  codenvy/che-launcher:nightly start

rm -rf tmp > /dev/null
```