### PR TITLE
Enable Che server debug configuration.

### DIFF
--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -60,6 +60,8 @@ init_global_variables() {
   DEFAULT_CHE_USER="root"
   DEFAULT_CHE_LOG_LEVEL="info"
   DEFAULT_CHE_DATA_FOLDER="/home/user/che"
+  DEFAULT_CHE_DEBUG_SERVER="false"
+  DEFAULT_CHE_DEBUG_SERVER_PORT="8000"
 
   # Clean eventual user provided paths
   CHE_CONF_FOLDER=${CHE_CONF_FOLDER:+$(get_converted_and_clean_path "${CHE_CONF_FOLDER}")}
@@ -78,6 +80,8 @@ init_global_variables() {
   CHE_HOST_IP=${CHE_HOST_IP:-${DEFAULT_DOCKER_HOST_IP}}
   CHE_LOG_LEVEL=${CHE_LOG_LEVEL:-${DEFAULT_CHE_LOG_LEVEL}}
   CHE_DATA_FOLDER=${CHE_DATA_FOLDER:-${DEFAULT_CHE_DATA_FOLDER}}
+  CHE_DEBUG_SERVER=${CHE_DEBUG_SERVER:-${DEFAULT_CHE_DEBUG_SERVER}}
+  CHE_DEBUG_SERVER_PORT=${CHE_DEBUG_SERVER_PORT:-${DEFAULT_CHE_DEBUG_SERVER_PORT}}
 
   CHE_CONF_LOCATION="${CHE_CONF_FOLDER}":"/conf" 
   CHE_STORAGE_LOCATION="${CHE_DATA_FOLDER}/storage":"/home/user/che/storage"
@@ -85,9 +89,13 @@ init_global_variables() {
   CHE_LOCAL_BINARY_LOCATION="${CHE_LOCAL_BINARY}":"/home/user/che"
 
   if [ "${CHE_LOG_LEVEL}" = "debug" ]; then
-    CHE_DEBUG_OPTION="--debug --log_level:debug"
+    CHE_DEBUG_OPTION="--log_level:debug"
   else
     CHE_DEBUG_OPTION=""
+  fi
+
+  if [ "${CHE_DEBUG_SERVER}" = "true" ]; then
+    CHE_DEBUG_OPTION="${CHE_DEBUG_OPTION} --debug"
   fi
 
   USAGE="

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -29,7 +29,7 @@ start_che_server() {
   fi
 
   info "${CHE_PRODUCT_NAME}: Starting container..."
-  docker_run_with_conf "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" \
+  docker_run_with_debug "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" \
                           --remote:"${CHE_HOST_IP}" \
                           -s:uid \
                           -s:client \

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -52,7 +52,7 @@ start_che_server() {
     info "${CHE_PRODUCT_NAME}: API - http://${CHE_HOST_IP}:${CHE_PORT}/swagger"
 
     if has_debug; then
-      info "${CHE_PRODUCT_NAME}: Debug - http://${CHE_HOST_IP}:${CHE_DEBUG_SERVER_PORT}"
+      info "${CHE_PRODUCT_NAME}: JPDA Debug - http://${CHE_HOST_IP}:${CHE_DEBUG_SERVER_PORT}"
     fi
   else
     error_exit "${CHE_PRODUCT_NAME}: Timeout waiting for server. Run \"docker logs ${CHE_SERVER_CONTAINER_NAME}\" to inspect the issue."
@@ -118,7 +118,7 @@ print_debug_info() {
     debug "CHE API URL               = http://${CHE_HOST_IP}:${CURRENT_CHE_PORT}/swagger"
     if has_debug; then
       CURRENT_CHE_DEBUG_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "8000/tcp") 0).HostPort }}' ${CHE_SERVER_CONTAINER_NAME})
-      debug "CHE DEBUG URL             = http://${CHE_HOST_IP}:${CURRENT_CHE_DEBUG_PORT}"  
+      debug "CHE JPDA DEBUG URL      = http://${CHE_HOST_IP}:${CURRENT_CHE_DEBUG_PORT}"  
     fi
 
     debug 'CHE LOGS                  = run `docker logs -f '${CHE_SERVER_CONTAINER_NAME}'`'

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -47,7 +47,13 @@ start_che_server() {
 
   if server_is_booted; then
     info "${CHE_PRODUCT_NAME}: Booted and reachable"
-    info "${CHE_PRODUCT_NAME}: http://${CHE_HOSTNAME}:${CHE_PORT}"
+    info "${CHE_PRODUCT_NAME}: Use - http://${CHE_HOSTNAME}:${CHE_PORT}"
+    info "${CHE_PRODUCT_NAME}: Use - http://${CHE_HOST_IP}:${CHE_PORT}"
+    info "${CHE_PRODUCT_NAME}: API - http://${CHE_HOST_IP}:${CHE_PORT}/swagger"
+
+    if has_debug; then
+      info "${CHE_PRODUCT_NAME}: Debug - http://${CHE_HOST_IP}:${CHE_DEBUG_SERVER_PORT}"
+    fi
   else
     error_exit "${CHE_PRODUCT_NAME}: Timeout waiting for server. Run \"docker logs ${CHE_SERVER_CONTAINER_NAME}\" to inspect the issue."
   fi
@@ -102,14 +108,19 @@ print_debug_info() {
   debug "CHE CONTAINER EXISTS      = $(che_container_exist && echo "YES" || echo "NO")"
   debug "CHE CONTAINER STATUS      = $(che_container_is_running && echo "running" || echo "stopped")"
   if che_container_is_running; then
-    debug "CHE SERVER STATUS         = $(server_is_booted && echo "running" || echo "stopped")"
+    debug "CHE SERVER STATUS         = $(server_is_booted && echo "running & api reachable" || echo "stopped")"
     debug "CHE IMAGE                 = $(get_che_container_image_name)"
     debug "CHE SERVER CONTAINER ID   = $(get_che_server_container_id)"
     debug "CHE CONF FOLDER           = $(get_che_container_conf_folder)"
     debug "CHE DATA FOLDER           = $(get_che_container_data_folder)"
     CURRENT_CHE_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort }}' ${CHE_SERVER_CONTAINER_NAME})
-    debug "CHE DASHBOARD URL         = http://${DEFAULT_CHE_HOSTNAME}:${CURRENT_CHE_PORT}"  
-    debug "CHE API URL               = http://${DEFAULT_CHE_HOSTNAME}:${CURRENT_CHE_PORT}/api"
+    debug "CHE USE URL               = http://${CHE_HOST_IP}:${CURRENT_CHE_PORT}"  
+    debug "CHE API URL               = http://${CHE_HOST_IP}:${CURRENT_CHE_PORT}/swagger"
+    if has_debug; then
+      CURRENT_CHE_DEBUG_PORT=$(docker inspect --format='{{ (index (index .NetworkSettings.Ports "8000/tcp") 0).HostPort }}' ${CHE_SERVER_CONTAINER_NAME})
+      debug "CHE DEBUG URL             = http://${CHE_HOST_IP}:${CURRENT_CHE_DEBUG_PORT}"  
+    fi
+
     debug 'CHE LOGS                  = run `docker logs -f '${CHE_SERVER_CONTAINER_NAME}'`'
   fi
   debug ""
@@ -121,6 +132,8 @@ print_debug_info() {
   debug "CHE_USER                  = ${CHE_USER}"
   debug "CHE_HOST_IP               = ${CHE_HOST_IP}"
   debug "CHE_LOG_LEVEL             = ${CHE_LOG_LEVEL}"
+  debug "CHE_DEBUG_SERVER          = ${CHE_DEBUG_SERVER}"
+  debug "CHE_DEBUG_SERVER_PORT     = ${CHE_DEBUG_SERVER_PORT}"
   debug "CHE_HOSTNAME              = ${CHE_HOSTNAME}"
   debug "CHE_DATA_FOLDER           = ${CHE_DATA_FOLDER}"
   debug "CHE_CONF_FOLDER           = ${CHE_CONF_FOLDER:-not set}"

--- a/che-launcher/launcher_funcs.sh
+++ b/che-launcher/launcher_funcs.sh
@@ -146,8 +146,7 @@ docker_run_with_conf() {
 
 docker_run_with_debug() {
   if has_debug; then
-    docker_run_with_conf -p "${CHE_DEBUG_SERVER_PORT}":"${CHE_DEBUG_SERVER_PORT}" \
-                         -e "JPDA_ADDRESS=${CHE_DEBUG_SERVER_PORT}" "$@"
+    docker_run_with_conf -p "${CHE_DEBUG_SERVER_PORT}":8000 "$@"
   else
     docker_run_with_conf "$@"
   fi

--- a/che-launcher/launcher_funcs.sh
+++ b/che-launcher/launcher_funcs.sh
@@ -144,6 +144,23 @@ docker_run_with_conf() {
   fi
 }
 
+docker_run_with_debug() {
+  if has_debug; then
+    docker_run_with_conf -p "${CHE_DEBUG_SERVER_PORT}":"${CHE_DEBUG_SERVER_PORT}" \
+                         -e "JPDA_ADDRESS=${CHE_DEBUG_SERVER_PORT}" "$@"
+  else
+    docker_run_with_conf "$@"
+  fi
+}
+
+has_debug() {
+  if [ "${CHE_DEBUG_SERVER}" = "false" ]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
 has_che_conf_path() {
   if [ "${CHE_CONF_FOLDER}" = "" ]; then
     return 1


### PR DESCRIPTION
1: Set CHE_DEBUG_SERVER=true to enable JPDA mode of tomcat inside of the Che server.
2. Set CHE_DEBUG_SERVER_PORT to any port - default = "8000".
3. Separates logging level from debugging.
4. Also has che-server publish the JPDA_PORT so that che IP / hostname can be used.