### PR TITLE
Add multi-Che support for launcher

### DIFF
--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -119,21 +119,19 @@ parse_command_line () {
     exit
   fi
 
-  for command_line_option in "$@"; do
-    case ${command_line_option} in
-      start|stop|restart|update|info)
-        CHE_SERVER_ACTION=${command_line_option}
-      ;;
-      -h|--help)
-        usage
-        exit
-      ;;
-      *)
-        # unknown option
-        error_exit "You passed an unknown command line option."
-      ;;
-    esac
-  done
+  case $1 in
+    start|stop|restart|update|info)
+      CHE_SERVER_ACTION=$1
+    ;;
+    -h|--help)
+      usage
+      exit
+    ;;
+    *)
+      # unknown option
+      error_exit "You passed an unknown command line option."
+    ;;
+  esac
 }
 
 # See: https://sipb.mit.edu/doc/safe-shell/
@@ -150,10 +148,12 @@ case ${CHE_SERVER_ACTION} in
     start_che_server
   ;;
   stop)
-    stop_che_server
+    shift
+    stop_che_server $@
   ;;
   restart)
-    restart_che_server
+    shift
+    restart_che_server $@
   ;;
   update)
     update_che_server

--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -106,7 +106,7 @@ init_global_variables() {
 Usage:
   docker run --rm -t -v /var/run/docker.sock:/var/run/docker.sock ${LAUNCHER_IMAGE_NAME} [COMMAND]
      start                              Starts ${CHE_MINI_PRODUCT_NAME} server
-     stop                               Stops ${CHE_MINI_PRODUCT_NAME} server
+     stop [<container_id>]              Stops ${CHE_MINI_PRODUCT_NAME} server
      restart                            Restart ${CHE_MINI_PRODUCT_NAME} server
      update                             Pull latest version of ${CHE_SERVER_IMAGE_NAME}
      info                               Print some debugging information

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -34,6 +34,7 @@ start_che_server() {
                           -s:client \
                           ${CHE_DEBUG_OPTION} \
                           run > /dev/null
+
   CURRENT_CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id ${CHE_SERVER_CONTAINER_NAME})
   wait_until_container_is_running 10 ${CURRENT_CHE_SERVER_CONTAINER_ID}
   if ! che_container_is_running ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
@@ -59,7 +60,12 @@ start_che_server() {
 }
 
 stop_che_server() {
-  CURRENT_CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id ${CHE_SERVER_CONTAINER_NAME})
+  if [ $# -gt 0 ]; then
+    CURRENT_CHE_SERVER_CONTAINER_ID=$1
+  else
+    CURRENT_CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id ${CHE_SERVER_CONTAINER_NAME})
+  fi
+
   if ! che_container_is_running $CURRENT_CHE_SERVER_CONTAINER_ID; then
     info "${CHE_PRODUCT_NAME}: Container is not running. Nothing to do."
   else
@@ -77,10 +83,16 @@ stop_che_server() {
 }
 
 restart_che_server() {
-  CURRENT_CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id ${CHE_SERVER_CONTAINER_NAME})
-  if che_container_is_running $CURRENT_CHE_SERVER_CONTAINER_ID; then
-    stop_che_server
+  if [ $# -gt 0 ]; then
+    CURRENT_CHE_SERVER_CONTAINER_ID=$1
+  else
+    CURRENT_CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id ${CHE_SERVER_CONTAINER_NAME})
   fi
+
+  if che_container_is_running $CURRENT_CHE_SERVER_CONTAINER_ID; then
+    stop_che_server $CURRENT_CHE_SERVER_CONTAINER_ID
+  fi
+
   start_che_server
 }
 

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -67,7 +67,7 @@ stop_che_server() {
   fi
 
   if ! che_container_is_running $CURRENT_CHE_SERVER_CONTAINER_ID; then
-    info "${CHE_PRODUCT_NAME}: Container is not running. Nothing to do."
+    info "${CHE_PRODUCT_NAME}: Container $CURRENT_CHE_SERVER_CONTAINER_ID is not running. Nothing to do."
   else
     info "${CHE_PRODUCT_NAME}: Stopping server..."
     docker exec ${CURRENT_CHE_SERVER_CONTAINER_ID} /home/user/che/bin/che.sh -c -s:uid stop > /dev/null

--- a/che-launcher/launcher_funcs.sh
+++ b/che-launcher/launcher_funcs.sh
@@ -28,7 +28,7 @@ error() {
 error_exit() {
   echo  "---------------------------------------"
   error "!!!"
-  error "!!! ${1}"
+  error "     ${1}"
   error "!!!"
   echo  "---------------------------------------"
   exit 1
@@ -287,8 +287,17 @@ inside the container. Verify the syntax of the \"docker run\" command."
   fi
 }
 
+che_container_exist_by_name() {
+  docker inspect ${1} > /dev/null 2>&1
+  if [ "$?" == "0" ]; then
+    return 0
+  else 
+    return 1
+  fi 
+}
+
 che_container_exist() {
-  if [ "$(docker ps -aq  -f "name=${CHE_SERVER_CONTAINER_NAME}" | wc -l)" -eq 0 ]; then
+  if [ "$(docker ps -aq  -f "id=${1}" | wc -l)" -eq 0 ]; then
     return 1
   else
     return 0
@@ -296,7 +305,7 @@ che_container_exist() {
 }
 
 che_container_is_running() {
-  if [ "$(docker ps -qa -f "status=running" -f "name=${CHE_SERVER_CONTAINER_NAME}" | wc -l)" -eq 0 ]; then
+  if [ "$(docker ps -qa -f "status=running" -f "id=${1}" | wc -l)" -eq 0 ]; then
     return 1
   else
     return 0
@@ -304,17 +313,55 @@ che_container_is_running() {
 }
 
 che_container_is_stopped() {
-  if [ "$(docker ps -qa -f "status=exited" -f "name=${CHE_SERVER_CONTAINER_NAME}" | wc -l)" -eq 0 ]; then
+  if [ "$(docker ps -qa -f "status=exited" -f "name=${1}" | wc -l)" -eq 0 ]; then
     return 1
   else
     return 0
   fi
 }
 
+has_container_debug () {
+  if [ $(get_container_debug $1) = "<nil>" ]; then
+    return 1
+  else
+    return 0
+  fi
+
+}
+
+get_container_debug() {
+  CURRENT_CHE_DEBUG=$(docker inspect --format='{{.NetworkSettings.Ports}}' ${1})
+  IFS=$' '
+  for SINGLE_BIND in $CURRENT_CHE_DEBUG; do
+    case $SINGLE_BIND in
+      *8000/tcp:*)
+        echo $SINGLE_BIND | cut -f2 -d":"
+      ;;
+      *)
+      ;;
+    esac
+  done
+}
+
+get_che_container_host_ip_from_container() {
+  BINDS=$(docker inspect --format="{{.Config.Cmd}}" "${1}" | cut -d '[' -f 2 | cut -d ']' -f 1)
+
+  IFS=$' '
+  for SINGLE_BIND in $BINDS; do
+    case $SINGLE_BIND in
+      *--remote*)
+        echo $SINGLE_BIND | cut -f2 -d":"
+      ;;
+      *)
+      ;;
+    esac
+  done
+}
 
 get_che_container_host_bind_folder() {
-  BINDS=$(docker inspect --format="{{.HostConfig.Binds}}" "${CHE_SERVER_CONTAINER_NAME}" | cut -d '[' -f 2 | cut -d ']' -f 1)
+  BINDS=$(docker inspect --format="{{.HostConfig.Binds}}" "${2}" | cut -d '[' -f 2 | cut -d ']' -f 1)
 
+  IFS=$' '
   for SINGLE_BIND in $BINDS; do
     case $SINGLE_BIND in
       *$1*)
@@ -327,21 +374,21 @@ get_che_container_host_bind_folder() {
 }
 
 get_che_container_conf_folder() {
-  FOLDER=$(get_che_container_host_bind_folder "/conf")
+  FOLDER=$(get_che_container_host_bind_folder "/conf:Z" $1)
   echo "${FOLDER:=not set}"
 }
 
 get_che_container_data_folder() {
-  FOLDER=$(get_che_container_host_bind_folder "/home/user/che/workspaces")
+  FOLDER=$(get_che_container_host_bind_folder "/home/user/che/workspaces:Z" $1)
   echo "${FOLDER:=not set}"
 }
 
 get_che_container_image_name() {
-  docker inspect --format="{{.Config.Image}}" "${CHE_SERVER_CONTAINER_NAME}"
+  docker inspect --format="{{.Config.Image}}" "${1}"
 }
 
 get_che_server_container_id() {
-  docker ps -q -a -f "name=${CHE_SERVER_CONTAINER_NAME}"
+  docker inspect -f '{{.Id}}' ${1}
 }
 
 get_docker_external_hostname() {
@@ -356,7 +403,7 @@ wait_until_container_is_running() {
   CONTAINER_START_TIMEOUT=${1}
 
   ELAPSED=0
-  until che_container_is_running || [ ${ELAPSED} -eq "${CONTAINER_START_TIMEOUT}" ]; do
+  until che_container_is_running ${2} || [ ${ELAPSED} -eq "${CONTAINER_START_TIMEOUT}" ]; do
     sleep 1
     ELAPSED=$((ELAPSED+1))
   done
@@ -366,14 +413,14 @@ wait_until_container_is_stopped() {
   CONTAINER_STOP_TIMEOUT=${1}
 
   ELAPSED=0
-  until che_container_is_stopped || [ ${ELAPSED} -eq "${CONTAINER_STOP_TIMEOUT}" ]; do
+  until che_container_is_stopped ${2} || [ ${ELAPSED} -eq "${CONTAINER_STOP_TIMEOUT}" ]; do
     sleep 1
     ELAPSED=$((ELAPSED+1))
   done
 }
 
 server_is_booted() {
-  HTTP_STATUS_CODE=$(curl -I http://$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${CHE_SERVER_CONTAINER_NAME}"):8080/api/ \
+  HTTP_STATUS_CODE=$(curl -I http://$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${1}"):8080/api/ \
                      -s -o /dev/null --write-out "%{http_code}")
   if [ "${HTTP_STATUS_CODE}" = "200" ]; then
     return 0
@@ -384,7 +431,7 @@ server_is_booted() {
 
 get_server_version() {
   HTTP_STATUS_CODE=$(curl -X OPTIONS http://$(docker inspect -f '{{.NetworkSettings.IPAddress}}' \
-                          "${CHE_SERVER_CONTAINER_NAME}"):8080/api/ -s)
+                          "${1}"):8080/api/ -s)
 
   FIRST=${HTTP_STATUS_CODE//\ /}
   IFS=','
@@ -403,7 +450,7 @@ wait_until_server_is_booted () {
   SERVER_BOOT_TIMEOUT=${1}
 
   ELAPSED=0
-  until server_is_booted || [ ${ELAPSED} -eq "${SERVER_BOOT_TIMEOUT}" ]; do
+  until server_is_booted ${2} || [ ${ELAPSED} -eq "${SERVER_BOOT_TIMEOUT}" ]; do
     sleep 1
     ELAPSED=$((ELAPSED+1))
   done

--- a/che-launcher/launcher_funcs.sh
+++ b/che-launcher/launcher_funcs.sh
@@ -320,13 +320,23 @@ che_container_is_stopped() {
   fi
 }
 
+contains() {
+    string="$1"
+    substring="$2"
+    if test "${string#*$substring}" != "$string"
+    then
+        return 0    # $substring is in $string
+    else
+        return 1    # $substring is not in $string
+    fi
+}
+
 has_container_debug () {
-  if [ $(get_container_debug $1) = "<nil>" ]; then
+  if $(contains $(get_container_debug $1) "<nil>"); then
     return 1
   else
     return 0
   fi
-
 }
 
 get_container_debug() {


### PR DESCRIPTION
This pull request improves the che-launcher to support running multiple Che servers on the same host. The particular issue that was experienced was that `che info` would assume that the only Che instance available was available through `CHE_SERVER_CONTAINER_NAME`. Third party utilities can launch multiple Che servers on different ports.

The set of changes do various things:
1. When starting or stopping a Che container, it uses the container_id that matches the name to determine if an exist che server container exists.  
2. When starting or stopping a Che container, it uses the container id to test server status instead of container name. This is essential because testing container name will return container ID for anything that matches the name - including other names that are derivatives of the name.
3. Adds functions to lookup a container id by a container name.
4. Modifies all of the che info functions to provide results by the container ID instead of container name.
5. Adds looping ability to print out instance info for every container running that matches the same image name.  If there are che servers running under different image names, then only the containers matching the `CHE_SERVER_IMAGE_NAME` will be returned.

Here is some sample output.
```
INFO: ---------------------------------------
INFO: ---------    CLI DEBUG INFO    --------
INFO: ---------------------------------------
INFO:
INFO: ---------  PLATFORM INFO  -------------
INFO: CLI DEFAULT PROFILE       = not set
INFO: CHE_VERSION               = nightly
INFO: CHE_UTILITY_VERSION       = nightly
INFO: DOCKER_INSTALL_TYPE       = docker4windows
INFO: DOCKER_HOST_IP            = 10.0.75.2
INFO: IS_NATIVE                 = NO
INFO: IS_WINDOWS                = YES
INFO: IS_DOCKER_FOR_WINDOWS     = YES
INFO: IS_DOCKER_FOR_MAC         = NO
INFO: IS_BOOT2DOCKER            = NO
INFO: HAS_DOCKER_FOR_WINDOWS_IP = YES
INFO: IS_MOBY_VM                = YES
INFO: HAS_CHE_ENV_VARIABLES     = YES
INFO: HAS_TEMP_CHE_PROPERTIES   = NO
INFO: IS_INTERACTIVE            = YES
INFO: IS_PSEUDO_TTY             = YES
INFO:
INFO: ---------------------------------------
INFO: ---------   LAUNCHER INFO  ------------
INFO: ---------------------------------------
INFO:
INFO: ---------  PLATFORM INFO  -------------
INFO: DOCKER_INSTALL_TYPE       = docker4windows
INFO: DOCKER_HOST_OS            = Alpine Linux v3.4
INFO: DOCKER_HOST_IP            = 10.0.75.2
INFO: DOCKER_HOST_EXTERNAL_IP   = localhost
INFO: DOCKER_DAEMON_VERSION     = 1.12.0
INFO:
INFO:
INFO: --------- CHE INSTANCE LIST  ----------
INFO:
INFO: --------- CHE INSTANCE INFO  ----------
INFO: CHE SERVER CONTAINER ID   = 0c5ebe1e336a
INFO: CHE SERVER CONTAINER NANE = che-server
INFO: CHE CONTAINER EXISTS      = YES
INFO: CHE CONTAINER STATUS      = running
INFO: CHE SERVER STATUS         = running & api reachable
INFO: CHE VERSION               = 5.0.0-M2-SNAPSHOT
INFO: CHE IMAGE                 = codenvy/che-server:nightly
INFO: CHE CONF FOLDER           = not set
INFO: CHE DATA FOLDER           = not set
INFO: CHE USE URL               = http://10.0.75.2:9100
INFO: CHE API URL               = http://10.0.75.2:9100/swagger
INFO: CHE LOGS                  = run `docker logs -f che-server`
INFO:
INFO: --------- CHE INSTANCE INFO  ----------
INFO: CHE SERVER CONTAINER ID   = a4b793104f47
INFO: CHE SERVER CONTAINER NANE = che-server-7ff136ba-8a30-4b11-9016-be6145ab4edf
INFO: CHE CONTAINER EXISTS      = YES
INFO: CHE CONTAINER STATUS      = running
INFO: CHE SERVER STATUS         = running & api reachable
INFO: CHE VERSION               = 5.0.0-M2-SNAPSHOT
INFO: CHE IMAGE                 = codenvy/che-server:nightly
INFO: CHE CONF FOLDER           = /c/codenvy/tmp/dir2/.che/conf
INFO: CHE DATA FOLDER           = not set
INFO: CHE USE URL               = http://10.0.75.2:9000
INFO: CHE API URL               = http://10.0.75.2:9000/swagger
INFO: CHE LOGS                  = run `docker logs -f che-server-7ff136ba-8a30-4b11-9016-be6145ab4edf`
INFO:
INFO: --------- CHE INSTANCE INFO  ----------
INFO: CHE SERVER CONTAINER ID   = 6aeeb469b8d0
INFO: CHE SERVER CONTAINER NANE = che-server-493b0ac6-e2e2-4dec-d196-5564c4f6bde7
INFO: CHE CONTAINER EXISTS      = YES
INFO: CHE CONTAINER STATUS      = running
INFO: CHE SERVER STATUS         = running & api reachable
INFO: CHE VERSION               = 5.0.0-M2-SNAPSHOT
INFO: CHE IMAGE                 = codenvy/che-server:nightly
INFO: CHE CONF FOLDER           = /c/codenvy/tmp/dir1/.che/conf
INFO: CHE DATA FOLDER           = not set
INFO: CHE USE URL               = http://10.0.75.2:8080
INFO: CHE API URL               = http://10.0.75.2:8080/swagger
INFO: CHE LOGS                  = run `docker logs -f che-server-493b0ac6-e2e2-4dec-d196-5564c4f6bde7`
INFO:
INFO:
INFO: ----  CURRENT COMMAND LINE OPTIONS  ---
INFO: CHE_PORT                  = 9100
INFO: CHE_VERSION               = nightly
INFO: CHE_RESTART_POLICY        = no
INFO: CHE_USER                  = root
INFO: CHE_HOST_IP               = 10.0.75.2
INFO: CHE_LOG_LEVEL             = info
INFO: CHE_DEBUG_SERVER          = false
INFO: CHE_DEBUG_SERVER_PORT     = 8000
INFO: CHE_HOSTNAME              = localhost
INFO: CHE_DATA_FOLDER           = /home/user/che
INFO: CHE_CONF_FOLDER           = not set
INFO: CHE_LOCAL_BINARY          = not set
INFO: CHE_SERVER_CONTAINER_NAME = che-server
INFO: CHE_SERVER_IMAGE_NAME     = codenvy/che-server
```