### PR TITLE
Improvements to che-mount

### DIFF
--- a/che-mount/Dockerfile
+++ b/che-mount/Dockerfile
@@ -11,13 +11,25 @@
 #  docker build -t codenvy/che-mount .
 #
 # LAUNCH CONTAINER:
-#  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse 
-#             -v /var/run/docker.sock:/var/run/docker.sock
+#  On linux:
+#  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
+#             --name che-mount
+#             -v ${HOME}/.ssh:${HOME}/.ssh
+#             -v ${HOME}/.unison:${HOME}/.unison 
+#             -v /etc/group:/etc/group:ro 
+#             -v /etc/passwd:/etc/passwd:ro 
+#             -u $(id -u ${USER})
+#             -v <host-dir>:/mnthost codenvy/che-mount <ip> <ws-port> 
+#            
+#  On Mac or Windows:
+#  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
+#             --name che-mount 
+#             -v ~/.ssh:/root/.ssh
 #             -v <host-dir>:/mnthost codenvy/che-mount <ip> <ws-port>
 #
 # RUN IN CONTAINER:
 #  echo "secret" | $(echo "yes" | sshfs user@10.0.75.2:/projects /mntssh -p 32774)
-#   
+#
 # TO UNMOUNT IN CONTAINER
 #  fusermount -u /mntssh
 #
@@ -29,15 +41,16 @@ ENV UNISON_VERSION=2.48.4
 
 RUN apk add --update build-base curl bash sshfs && \
     apk add ocaml --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted && \
-    curl -L https://www.seas.upenn.edu/~bcpierce/unison//download/releases/unison-$UNISON_VERSION/unison-$UNISON_VERSION.tar.gz | tar xzv -C /tmp && \
+    curl -L https://www.seas.upenn.edu/~bcpierce/unison/download/releases/unison-$UNISON_VERSION/unison-$UNISON_VERSION.tar.gz | tar xzv -C /tmp && \
     cd /tmp/src && \
     sed -i -e 's/GLIBC_SUPPORT_INOTIFY 0/GLIBC_SUPPORT_INOTIFY 1/' fsmonitor/linux/inotify_stubs.c && \
     make && \
     cp /tmp/src/unison /usr/local/bin && \
+    cp /tmp/src/unison-fsmonitor /usr/local/bin && \
     apk del ocaml curl build-base bash && \
     rm -rf /tmp /var/cache/apk/* && \
-    mkdir /mntssh && \
-    mkdir /mnthost
+    mkdir /mntssh && chmod -R 777 /mntssh && \
+    mkdir /mnthost && chmod -R 777 /mnthost
 
 COPY /sync.sh /bin/sync.sh
 

--- a/che-mount/sync.sh
+++ b/che-mount/sync.sh
@@ -88,15 +88,14 @@ if [ $status -ne 0 ]; then
     exit 1
 fi
 info "INFO: ECLIPSE CHE: Successfully mounted user@$1:/projects"
-info "INFO: ECLIPSE CHE: First syncronisation is happening now and can take a long time. Please wait."
+info "INFO: ECLIPSE CHE: Intial sync...Please wait."
 unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer -log=false > /dev/null 2>&1
 status=$?
 if [ $status -ne 0 ]; then
     error "ERROR: Fatal error occurred ($status)"
     exit 1
 fi
-info "INFO: ECLIPSE CHE: First syncronisation completed."
-info "INFO: ECLIPSE CHE: Now synchronization happens continuously every ${UNISON_REPEAT_DELAY_IN_SEC} seconds."
+info "INFO: ECLIPSE CHE: Background sync continues every ${UNISON_REPEAT_DELAY_IN_SEC} seconds."
 
 # -repeat=watch doesn't work because SSHFS doesn't support inotify and 
 # unison-fsmonitor rely on inotify

--- a/che-mount/sync.sh
+++ b/che-mount/sync.sh
@@ -18,13 +18,27 @@ init_logging() {
 init_global_variables() {
 
   USAGE="
-Usage:
-  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse 
-             -v <local-mount>/:/mnthost codenvy/che-mount <ip> <port>
+Usage on Linux 
+  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
+            --name che-mount
+            -v \${HOME}/.ssh:\${HOME}/.ssh
+            -v \${HOME}/.unison:\${HOME}/.unison 
+            -v /etc/group:/etc/group:ro 
+            -v /etc/passwd:/etc/passwd:ro 
+            -u \$(id -u \${USER})
+            -v <local-mount>/:/mnthost codenvy/che-mount <ip> <port> 
+           
+Usage on Mac or Windows:
+  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
+            --name che-mount 
+            -v ~/.ssh:/root/.ssh
+            -v <local-mount>/:/mnthost codenvy/che-mount <ip> <port>
+
      <local-mount>    Host directory to sync files, must end with a slash '/'
      <ip>             IP address of Che server
      <port>           Port of workspace SSH server - retrieve inside workspace
 "
+ UNISON_REPEAT_DELAY_IN_SEC=2
 }
 
 parse_command_line () {
@@ -60,20 +74,35 @@ error_exit() {
 }
 
 # See: https://sipb.mit.edu/doc/safe-shell/
-set -e
 set -u
 
 init_logging
 init_global_variables
 parse_command_line "$@"
 
+info "INFO: ECLIPSE CHE: Mounting user@$1:/projects with SSHFS"
 sshfs user@$1:/projects /mntssh -p $2
-unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer > /dev/null 2>&1
-
+status=$?
+if [ $status -ne 0 ]; then
+    error "ERROR: Fatal error occurred ($status)"
+    exit 1
+fi
 info "INFO: ECLIPSE CHE: Successfully mounted user@$1:/projects"
- 
-while :
-do
-    unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer > /dev/null 2>&1
-    sleep 1
-done
+info "INFO: ECLIPSE CHE: First syncronisation is happening now and can take a long time. Please wait."
+unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer -log=false > /dev/null 2>&1
+status=$?
+if [ $status -ne 0 ]; then
+    error "ERROR: Fatal error occurred ($status)"
+    exit 1
+fi
+info "INFO: ECLIPSE CHE: First syncronisation completed."
+info "INFO: ECLIPSE CHE: Now synchronization happens continuously every ${UNISON_REPEAT_DELAY_IN_SEC} seconds."
+
+# -repeat=watch doesn't work because SSHFS doesn't support inotify and 
+# unison-fsmonitor rely on inotify
+unison /mntssh /mnthost -batch -retry 10 -fat -silent -copyonconflict -auto -prefer=newer -repeat=${UNISON_REPEAT_DELAY_IN_SEC} -log=false  > /dev/null 2>&1
+status=$?
+if [ $status -ne 0 ]; then
+    error "ERROR: Fatal error occurred ($status)"
+    exit 1
+fi


### PR DESCRIPTION
  - Included unison-fsmonitor to use unison `-repeat` option
  - More unison options: -copyonconflict -auto -prefer=newer -log=false
  - Added linux specific syntax to run che-mount in container