### PR TITLE
change Node version to 4.6.0 LTS

### DIFF
--- a/recipes/node/ubuntu/Dockerfile
+++ b/recipes/node/ubuntu/Dockerfile
@@ -7,7 +7,7 @@
 # Codenvy, S.A. - initial API and implementation
 
 FROM codenvy/ubuntu_jre
-ENV NODE_VERSION=0.12.9 \
+ENV NODE_VERSION=4.6.0 \
     NODE_PATH=/usr/local/lib/node_modules
     
 RUN sudo apt-get update && \


### PR DESCRIPTION
the following has the ability to read arrow funcs (as far as I'm concerned), still needs testing.

let me know is errors arises from this.