### PR TITLE
Add Ignore path-specification to codenvy/che-mount utility

### DIFF
--- a/che-mount/sync.sh
+++ b/che-mount/sync.sh
@@ -74,7 +74,7 @@ error() {
 }
 
 stop_sync() {
-  echo "Recived interrupt signal. Exiting."
+  echo "Received interrupt signal. Exiting."
   exit 1
 }
 
@@ -96,7 +96,7 @@ if [ $status -ne 0 ]; then
     exit 1
 fi
 info "INFO: (che mount): Successfully mounted user@$1:/projects"
-info "INFO: (che mount): Intial sync...Please wait."
+info "INFO: (che mount): Initial sync...Please wait."
 unison /mntssh /mnthost -batch -fat -silent -auto -prefer=newer -log=false > /dev/null 2>&1
 status=$?
 if [ $status -ne 0 ]; then
@@ -105,19 +105,7 @@ if [ $status -ne 0 ]; then
 fi
 info "INFO: (che mount): Background sync continues every ${UNISON_REPEAT_DELAY_IN_SEC} seconds."
 info "INFO: (che mount): This terminal will block while the synchronization continues."
-info "INFO: (che mount): To stop, issue a SIGTERM, usually CTRL-C."
+info "INFO: (che mount): To stop, issue a SIGTERM or SIGINT, usually CTRL-C."
 
 # run application
 unison /mntssh /mnthost -batch -retry 10 -fat -silent -copyonconflict -auto -prefer=newer -repeat=${UNISON_REPEAT_DELAY_IN_SEC} -log=false > /dev/null 2>&1
-#PID=$!
-#echo "hi"
-# See: http://veithen.github.io/2014/11/16/sigterm-propagation.html
-#wait $PID
-#wait $PID
-#EXIT_STATUS=$?
-
-# wait forever
-#while true
-#do
-#  tail -f /dev/null & wait ${!}
-#done


### PR DESCRIPTION
This adds a capability to the codenvy/che-mount utility that improves synchronization performance by allowing users of the utility to provide a unison profile that contains matching files, directories along with patterns that can be ignored.  By ignoring large directories or certain patterns, the synchronization can be improved performance-wise.

Please note - the syntax has been modified.  It is no longer necessary to volume mount the .ssh directory.   To provide a unison profile, create a file named `default.prf`.  You can provide any valid unison profile for this, which include name patterns, regex.  You then need to mount the directory where this file resides to `/profile` in the container.

[Docs on Profiles](https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#profile)
[Docs on Ignore](https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#ignore)

TODO - Che CLI will need to be updated to remove the .ssh mount and to also provide this file as a hard coded file.  Perhaps we have people place it in ~/.che/unison/default.prf.  We will always expect it there, if it is provided at all.
 
```
Usage on Linux 
  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
            --name che-mount
            -v /etc/group:/etc/group:ro 
            -v /etc/passwd:/etc/passwd:ro 
            -v <path-to-sync-profile>:/profile
            -u \$(id -u \${USER})
            -v <local-mount>/:/mnthost codenvy/che-mount <ip> <port> 
           
Usage on Mac or Windows:
  docker run --rm -it --cap-add SYS_ADMIN --device /dev/fuse
            --name che-mount 
            -v <path-to-sync-profile>:/profile
            -v <local-mount>/:/mnthost codenvy/che-mount <ip> <port>

     <local-mount>    Host directory to sync files, must end with a slash '/'
     <ip>             IP address of Che server
     <port>           Port of workspace SSH server - retrieve inside workspace
```

To build this container for usage now, you can:
```
git clone http://github.com/eclipse/che-dockerfiles
cd che-dockerfiles
git checkout add-ignore-mount
cd che-mount
docker build -t codenvy/che-mount:nightly .
```