### PR TITLE
Updates to support improvements to che-server Docker container

### DIFF
--- a/che-launcher/launcher.sh
+++ b/che-launcher/launcher.sh
@@ -59,16 +59,25 @@ init_global_variables() {
   DEFAULT_CHE_RESTART_POLICY="no"
   DEFAULT_CHE_USER="root"
   DEFAULT_CHE_LOG_LEVEL="info"
-  DEFAULT_CHE_DATA_FOLDER="/home/user/che"
   DEFAULT_CHE_DEBUG_SERVER="false"
   DEFAULT_CHE_DEBUG_SERVER_PORT="8000"
   DEFAULT_CHE_DEBUG_SERVER_SUSPEND="false"
   DEFAULT_CHE_DOCKER_MACHINE_HOST_EXTERNAL=$(get_docker_external_hostname)
 
   # Clean eventual user provided paths
-  CHE_CONF_FOLDER=${CHE_CONF_FOLDER:+$(get_converted_and_clean_path "${CHE_CONF_FOLDER}")}
-  CHE_DATA_FOLDER=${CHE_DATA_FOLDER:+$(get_converted_and_clean_path "${CHE_DATA_FOLDER}")}
-  CHE_LOCAL_BINARY=${CHE_LOCAL_BINARY:+$(get_converted_and_clean_path "${CHE_LOCAL_BINARY}")}
+  CHE_CONF=${CHE_CONF:+$(get_converted_and_clean_path "${CHE_CONF}")}
+  CHE_CONF_LOCATION="${CHE_CONF}":"${CHE_CONF}:Z"
+  # "<-- Added comment with quote to fix broken syntax highlighting
+
+  DEFAULT_CHE_DATA_FOLDER="/home/user/che"
+  CHE_DATA=${CHE_DATA:+$(get_converted_and_clean_path "${CHE_DATA}")}
+  CHE_DATA=${CHE_DATA:-${DEFAULT_CHE_DATA_FOLDER}}
+  CHE_DATA_LOCATION="${CHE_DATA}":"/data:Z"
+  # "<-- Added comment with quote to fix broken syntax highlighting
+
+  CHE_ASSEMBLY=${CHE_ASSEMBLY:+$(get_converted_and_clean_path "${CHE_ASSEMBLY}")}
+  CHE_ASSEMBLY_LOCATION="${CHE_ASSEMBLY}":"${CHE_ASSEMBLY}:Z"
+  # "<-- Added comment with quote to fix broken syntax highlighting
 
   CHE_PRODUCT_NAME=${CHE_PRODUCT_NAME:-${DEFAULT_CHE_PRODUCT_NAME}}
   CHE_MINI_PRODUCT_NAME=${CHE_MINI_PRODUCT_NAME:-${DEFAULT_CHE_MINI_PRODUCT_NAME}}
@@ -81,26 +90,10 @@ init_global_variables() {
   CHE_USER=${CHE_USER:-${DEFAULT_CHE_USER}}
   CHE_HOST_IP=${CHE_HOST_IP:-${DEFAULT_DOCKER_HOST_IP}}
   CHE_LOG_LEVEL=${CHE_LOG_LEVEL:-${DEFAULT_CHE_LOG_LEVEL}}
-  CHE_DATA_FOLDER=${CHE_DATA_FOLDER:-${DEFAULT_CHE_DATA_FOLDER}}
   CHE_DEBUG_SERVER=${CHE_DEBUG_SERVER:-${DEFAULT_CHE_DEBUG_SERVER}}
   CHE_DEBUG_SERVER_PORT=${CHE_DEBUG_SERVER_PORT:-${DEFAULT_CHE_DEBUG_SERVER_PORT}}
   CHE_DEBUG_SERVER_SUSPEND=${CHE_DEBUG_SERVER_SUSPEND:-${DEFAULT_CHE_DEBUG_SERVER_SUSPEND}}
   CHE_DOCKER_MACHINE_HOST_EXTERNAL=${CHE_DOCKER_MACHINE_HOST_EXTERNAL:-${DEFAULT_CHE_DOCKER_MACHINE_HOST_EXTERNAL}}
-
-  CHE_CONF_LOCATION="${CHE_CONF_FOLDER}":"/conf:Z"
-  CHE_STORAGE_LOCATION="${CHE_DATA_FOLDER}/storage":"/home/user/che/storage:Z"
-  CHE_WORKSPACE_LOCATION="${CHE_DATA_FOLDER}/workspaces":"/home/user/che/workspaces:Z"
-  CHE_LOCAL_BINARY_LOCATION="${CHE_LOCAL_BINARY}":"/home/user/che:Z"
-
-  if [ "${CHE_LOG_LEVEL}" = "debug" ]; then
-    CHE_DEBUG_OPTION="--log_level:debug"
-  else
-    CHE_DEBUG_OPTION=""
-  fi
-
-  if [ "${CHE_DEBUG_SERVER}" = "true" ]; then
-    CHE_DEBUG_OPTION="${CHE_DEBUG_OPTION} --debug"
-  fi
 
   USAGE="
 Usage:

--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -28,12 +28,7 @@ start_che_server() {
   fi
 
   info "${CHE_PRODUCT_NAME}: Starting container..."
-  docker_run_with_debug "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" \
-                          --remote:"${CHE_HOST_IP}" \
-                          -s:uid \
-                          -s:client \
-                          ${CHE_DEBUG_OPTION} \
-                          run > /dev/null
+  docker_run_with_debug "${CHE_SERVER_IMAGE_NAME}":"${CHE_VERSION}" > /dev/null
 
   CURRENT_CHE_SERVER_CONTAINER_ID=$(get_che_server_container_id ${CHE_SERVER_CONTAINER_NAME})
   wait_until_container_is_running 10 ${CURRENT_CHE_SERVER_CONTAINER_ID}
@@ -70,7 +65,7 @@ stop_che_server() {
     info "${CHE_PRODUCT_NAME}: Container $CURRENT_CHE_SERVER_CONTAINER_ID is not running. Nothing to do."
   else
     info "${CHE_PRODUCT_NAME}: Stopping server..."
-    docker exec ${CURRENT_CHE_SERVER_CONTAINER_ID} /home/user/che/bin/che.sh -c -s:uid stop > /dev/null
+    docker stop ${CURRENT_CHE_SERVER_CONTAINER_ID} > /dev/null
     wait_until_container_is_stopped 60 ${CURRENT_CHE_SERVER_CONTAINER_ID}
     if che_container_is_running ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
       error_exit "${CHE_PRODUCT_NAME}: Timeout waiting for the ${CHE_PRODUCT_NAME} container to stop."
@@ -123,8 +118,7 @@ print_debug_info() {
   IFS=$'\n'
   for CHE_SERVER_CONTAINER_ID in $CURRENT_CHE_INSTANCES; do
     info ""
-    info "--------- CHE INSTANCE INFO  ----------" 
-    info "CHE SERVER CONTAINER ID   = $CHE_SERVER_CONTAINER_ID"
+    info "--------- CHE INSTANCE: $CHE_SERVER_CONTAINER_ID" 
     CURRENT_CHE_SERVER_CONTAINER_NAME=$(docker inspect --format='{{.Name}}' ${CHE_SERVER_CONTAINER_ID} | cut -f2 -d"/") 
     info "CHE SERVER CONTAINER NANE = $CURRENT_CHE_SERVER_CONTAINER_NAME"
     info "CHE CONTAINER EXISTS      = $(che_container_exist $CHE_SERVER_CONTAINER_ID && echo "YES" || echo "NO")"
@@ -149,18 +143,18 @@ print_debug_info() {
   info ""
   info ""
   info "----  CURRENT COMMAND LINE OPTIONS  ---" 
-  info "CHE_PORT                  = ${CHE_PORT}"
   info "CHE_VERSION               = ${CHE_VERSION}"
+  info "CHE_DATA                  = ${CHE_DATA}"
+  info "CHE_CONF                  = ${CHE_CONF:-not set}"
+  info "CHE_ASSEMBLY              = ${CHE_ASSEMBLY:-not set}"
+  info "CHE_PORT                  = ${CHE_PORT}"
+  info "CHE_HOST_IP               = ${CHE_HOST_IP}"
   info "CHE_RESTART_POLICY        = ${CHE_RESTART_POLICY}"
   info "CHE_USER                  = ${CHE_USER}"
-  info "CHE_HOST_IP               = ${CHE_HOST_IP}"
   info "CHE_LOG_LEVEL             = ${CHE_LOG_LEVEL}"
   info "CHE_DEBUG_SERVER          = ${CHE_DEBUG_SERVER}"
   info "CHE_DEBUG_SERVER_PORT     = ${CHE_DEBUG_SERVER_PORT}"
   info "CHE_HOSTNAME              = ${CHE_HOSTNAME}"
-  info "CHE_DATA_FOLDER           = ${CHE_DATA_FOLDER}"
-  info "CHE_CONF_FOLDER           = ${CHE_CONF_FOLDER:-not set}"
-  info "CHE_LOCAL_BINARY          = ${CHE_LOCAL_BINARY:-not set}"
   info "CHE_SERVER_CONTAINER_NAME = ${CHE_SERVER_CONTAINER_NAME}"
   info "CHE_SERVER_IMAGE_NAME     = ${CHE_SERVER_IMAGE_NAME}"
 }


### PR DESCRIPTION
The Che Dockerfile has been improved to remove the number of volume mounts that are required.  Also, certain environment variables have been simplified.  This includes a series of changes to reflect these improvements.  We need to update some of the docs as the following environment variables have changed.

```
CHE_DATA_FOLDER --> CHE_DATA
CHE_CONF_FOLDER --> CHE_CONF
CHE_LOCAL_BINARY --> CHE_ASSEMBLY
```
If a user does not provide the `CHE_DATA` folder, Che will start with writing all files into /home/user/che and they will not exist if you restart Che on Windows.
