### PR TITLE
Preserve pio files between workspace restart

### DIFF
--- a/recipes/platformio/Dockerfile
+++ b/recipes/platformio/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse/ubuntu_python:2.7
 
+ENV PLATFORMIO_HOME_DIR /projects/.platformio
 # After 3.2 release replace with sudo  pip install -U platformio
 RUN sudo pip install https://github.com/platformio/platformio/archive/develop.zip


### PR DESCRIPTION
This pr configure storage of platformio files inside of project directory.
This is change is need to preserve downloaded by platformio files between workspace
restarts in case if snapshots is turned off. 
Related to https://github.com/eclipse/che/pull/2887