### PR TITLE
Add support for Docker For Windows 1.12.3

### DIFF
--- a/che-ip/getip.sh
+++ b/che-ip/getip.sh
@@ -10,9 +10,11 @@ NETWORK_IF=
 
 # handle docker for windows/mac
 if uname -r | grep -q 'moby'; then
-  if [ -d "/sys/class/net/eth0" ]; then
+  if [ -d "/sys/class/net/hvint0" ]; then
+    NETWORK_IF=hvint0
+  elif [ -d "/sys/class/net/eth0" ]; then
     NETWORK_IF=eth0
-   fi
+  fi
 fi
 
 if test -z ${NETWORK_IF}; then


### PR DESCRIPTION
It expects ethernet interface to be hvint0

Change-Id: Ie801f75f8a6055219e62e1d7c0310174ab10bd67
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>