### PR TITLE
Display localhost instead of the internal docker ip when using docker for mac

### DIFF
--- a/che-launcher/launcher_cmds.sh
+++ b/che-launcher/launcher_cmds.sh
@@ -43,8 +43,13 @@ start_che_server() {
   if server_is_booted ${CURRENT_CHE_SERVER_CONTAINER_ID}; then
     info "${CHE_PRODUCT_NAME}: Booted and reachable"
     info "${CHE_PRODUCT_NAME}: Ver: $(get_server_version ${CURRENT_CHE_SERVER_CONTAINER_ID})"
-    info "${CHE_PRODUCT_NAME}: Use: http://${CHE_HOST_IP}:${CHE_PORT}"
-    info "${CHE_PRODUCT_NAME}: API: http://${CHE_HOST_IP}:${CHE_PORT}/swagger"
+    if ! is_docker_for_mac; then
+      info "${CHE_PRODUCT_NAME}: Use: http://${CHE_HOST_IP}:${CHE_PORT}"
+      info "${CHE_PRODUCT_NAME}: API: http://${CHE_HOST_IP}:${CHE_PORT}/swagger"
+    else
+      info "${CHE_PRODUCT_NAME}: Use: http://localhost:${CHE_PORT}"
+      info "${CHE_PRODUCT_NAME}: API: http://localhost:${CHE_PORT}/swagger"
+    fi
 
     if has_debug; then
       info "${CHE_PRODUCT_NAME}: JPDA Debug - http://${CHE_HOST_IP}:${CHE_DEBUG_SERVER_PORT}"


### PR DESCRIPTION
It avoids to define ifconfig alias to loopback interface

now on mac:
```
$ ./che.sh start
INFO: ECLIPSE CHE: Found image eclipse/che-server:nightly
INFO: ECLIPSE CHE: Starting container...
INFO: ECLIPSE CHE: Server logs at "docker logs -f che-server"
INFO: ECLIPSE CHE: Server booting...
INFO: ECLIPSE CHE: Booted and reachable
INFO: ECLIPSE CHE: Ver: 5.0.0-M7-SNAPSHOT
INFO: ECLIPSE CHE: Use: http://localhost:8080
INFO: ECLIPSE CHE: API: http://localhost:8080/swagger

```

Change-Id: Ic9dc4b7440a978a69eaee0c1980089905814ac66
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>