### PR TITLE
build Platformio image with ubuntu 14.04

### DIFF
--- a/recipes/platformio/Dockerfile
+++ b/recipes/platformio/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse/ubuntu_python:2.7
-
+FROM eclipse/ubuntu_jre
+RUN sudo apt-get update && sudo apt-get -y install python-pip
 # After 3.2 release replace with sudo  pip install -U platformio
 RUN sudo pip install https://github.com/platformio/platformio/archive/develop.zip


### PR DESCRIPTION
There is some  issue in certain PlatformIO commands like ```pio remote run ...```  with eclipse/ubuntu_python:2.7 It can be related to the way how we install python in ubuntu 16.04.
I don't know why it happened or it can related to ubuntu image itself. Because command
is working on ubuntu:trusty
```bash

docker run  -it \
    -v /Users/sj/dev/src/pi2/platformio-examples/atmelavr-and-arduino:/projects \
    -e "CHE_API=https://codenvy.io/api" \
    -e "PLATFORMIO_AUTH_TOKEN=your token here" \
    ubuntu:trusty \
    bash -c "apt-get update && apt-get -y install python-pip && pip install -U https://github.com/platformio/platformio/archive/develop.zip && pio remote run -e uno -d /projects/arduino-blink"
````
but it's not working on Xenial. I think it's somehow related to the fact that Xenial has Python3 installed by default. More strange that with Vagrant 
````
Vagrant.configure("2") do |config|
  #config.vm.box = "ubuntu/trusty64"
  config.vm.box = "ubuntu/xenial64"
  config.vm.synced_folder "platformio-examples/atmelavr-and-arduino/", "/projects"

   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
     apt-get -y install python-pip
     pip install -U https://github.com/platformio/platformio/archive/develop.zip 
     CHE_API=https://codenvy.io/api;export PLATFORMIO_AUTH_TOKEN=65cc623e3ee6fe83a937c1a632a651bcf7b5dc57;pio remote run -e uno -d /projects/arduino-blink
   SHELL
end
````

 work perfectly on both ubuntu versions.
