### PR TITLE
Migrate OracleJDK to OpenJDK in images

### DIFF
--- a/recipes/artik/Dockerfile
+++ b/recipes/artik/Dockerfile
@@ -9,9 +9,7 @@
 FROM fedora:24
 ENV CC arm-linux-gnueabi-gcc
 ENV CXX arm-linux-gnueabi-g++
-ENV JAVA_VERSION=8u65 \
-    JAVA_VERSION_PREFIX=1.8.0_65
-ENV JAVA_HOME /opt/jre$JAVA_VERSION_PREFIX
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
 ENV PATH $JAVA_HOME/bin:$PATH
 ENV CPATH=/usr/arm-linux-gnueabi/sys-root/usr/include/artik
 ENV NODE_PATH=/usr/local/lib/node_modules
@@ -19,7 +17,7 @@ ENV CROSS_COMPILE=arm-linux-gnueabi- \
     SYSROOT=/usr/arm-linux-gnueabi/sys-root
     
 RUN dnf update -y && \
-    dnf install dnf-plugins-core copr-cli -y && \
+    dnf install dnf-plugins-core copr-cli java-1.8.0-openjdk-devel.x86_64 -y && \
     dnf copr enable lantw44/arm-linux-gnueabi-toolchain -y && \
     dnf --enablerepo='*debug*' install android-tools arm-linux-gnueabi-{binutils,gcc,glibc} sudo usbutils openssh-server procps wget unzip mc git curl openssl bash passwd tar gdb sshpass cpio subversion -y && \
     dnf clean all && \
@@ -27,13 +25,8 @@ RUN dnf update -y && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    wget \
-    --no-cookies \
-    --no-check-certificate \
-    --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-    -qO- "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b17/jre-$JAVA_VERSION-linux-x64.tar.gz" | tar -zx -C /opt/ && \
     echo -e "#! /bin/bash\n set -e\nsudo /usr/bin/ssh-keygen -A\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /root/entrypoint.sh && chmod a+x /root/entrypoint.sh && \
-    echo -e "export JAVA_HOME=/opt/jre$JAVA_VERSION_PREFIX\nexport CC=arm-linux-gnueabi-gcc\n export CXX=arm-linux-gnueabi-g++\nexport PATH=$JAVA_HOME/bin:$PATH" >> /root/.bashrc
+    echo -e "export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk\n export CC=arm-linux-gnueabi-gcc\n export CXX=arm-linux-gnueabi-g++\nexport PATH=$JAVA_HOME/bin:$PATH" >> /root/.bashrc
 RUN cd / && wget https://install.codenvycorp.com/artik/artik-libs-deps.zip
 RUN unzip -q artik-libs-deps.zip -d /usr/arm-linux-gnueabi/sys-root && rm artik-libs-deps.zip
 ADD artik.repo /etc/yum.repos.d/artik.repo

--- a/recipes/aspnet/Dockerfile
+++ b/recipes/aspnet/Dockerfile
@@ -7,17 +7,17 @@
 # Codenvy, S.A. - initial API and implementation
 
 FROM debian:wheezy
-ENV JAVA_VERSION=8u65 \
-    JAVA_VERSION_PREFIX=1.8.0_65
-ENV JAVA_HOME /opt/jre$JAVA_VERSION_PREFIX
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get update && \
+RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.list && \
+    apt-get update && \
     apt-get -y install \
     openssh-server \
     sudo \
     procps \
     wget \
     unzip \
+    openjdk-8-jdk \
     mc \
     locales \
     ca-certificates \
@@ -32,12 +32,6 @@ RUN PASS=$(openssl rand -base64 32) && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
     sudo apt-get install git subversion -y && \
     apt-get clean && \
-    wget \
-   --no-cookies \
-   --no-check-certificate \
-   --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-   -qO- \
-   "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b17/jre-$JAVA_VERSION-linux-x64.tar.gz" | tar -zx -C /opt/ && \
     apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* && \

--- a/recipes/aspnet/Dockerfile
+++ b/recipes/aspnet/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.lis
     procps \
     wget \
     unzip \
-    openjdk-8-jdk-headless \
+    openjdk-8-jre-headless \
     mc \
     locales \
     ca-certificates \

--- a/recipes/aspnet/Dockerfile
+++ b/recipes/aspnet/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.lis
     procps \
     wget \
     unzip \
-    openjdk-8-jdk \
+    openjdk-8-jdk-headless \
     mc \
     locales \
     ca-certificates \

--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -9,7 +9,7 @@
 FROM centos
 EXPOSE 4403 8080 8000 22
 RUN yum update -y && \
-    yum -y install sudo openssh-server procps wget unzip mc git curl subversion nmap java-1.8.0-openjdk java-1.8.0-openjdk-devel && \
+    yum -y install sudo openssh-server procps wget unzip mc git curl subversion nmap java-1.8.0-openjdk-devel && \
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \

--- a/recipes/debian_jdk8/Dockerfile
+++ b/recipes/debian_jdk8/Dockerfile
@@ -8,8 +8,9 @@
 
 FROM debian:jessie
 EXPOSE 4403 8080 8000 22
-RUN apt-get update && \
-    apt-get -y install locales openssh-server sudo procps wget unzip mc git curl subversion nmap  && \
+RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -y install locales openssh-server sudo procps wget unzip openjdk-8-jdk mc git curl subversion nmap  && \
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
@@ -24,22 +25,14 @@ LABEL che:server:8080:ref=tomcat8 che:server:8080:protocol=http che:server:8000:
 
 
 ENV MAVEN_VERSION=3.3.9 \
-    JAVA_VERSION=8u45 \
-    JAVA_VERSION_PREFIX=1.8.0_45 \
+    JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 \
     TOMCAT_HOME=/home/user/tomcat8
 
-ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX \
-M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
+ENV M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
 
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
 RUN mkdir /home/user/cbuild /home/user/tomcat8 /home/user/apache-maven-$MAVEN_VERSION && \
-  wget \
-  --no-cookies \
-  --no-check-certificate \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-  -qO- \
-  "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b14/jdk-$JAVA_VERSION-linux-x64.tar.gz" | sudo tar -zx -C /opt/ && \
   wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
 
 ENV TERM xterm

--- a/recipes/debian_jdk8/Dockerfile
+++ b/recipes/debian_jdk8/Dockerfile
@@ -10,7 +10,7 @@ FROM debian:jessie
 EXPOSE 4403 8080 8000 22
 RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get -y install locales openssh-server sudo procps wget unzip openjdk-8-jdk mc git curl subversion nmap  && \
+    apt-get -y install locales openssh-server sudo procps wget unzip openjdk-8-jdk-headless mc git curl subversion nmap  && \
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \

--- a/recipes/debian_jre/Dockerfile
+++ b/recipes/debian_jre/Dockerfile
@@ -7,15 +7,15 @@
 # Codenvy, S.A. - initial API and implementation
 
 FROM debian:jessie
-ENV JAVA_VERSION=8u65 \
-    JAVA_VERSION_PREFIX=1.8.0_65
-ENV JAVA_HOME /opt/jre$JAVA_VERSION_PREFIX
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 \
 ENV PATH $JAVA_HOME/bin:$PATH
-RUN apt-get update && \
+RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.list && \
+    apt-get update && \
     apt-get -y install \
     openssh-server \
     sudo \
     procps \
+    openjdk-8-jre \
     wget \
     unzip \
     mc \
@@ -32,12 +32,6 @@ RUN PASS=$(openssl rand -base64 32) && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
     sudo apt-get install git subversion -y && \
     apt-get clean && \
-    wget \
-   --no-cookies \
-   --no-check-certificate \
-   --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-   -qO- \
-   "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b17/jre-$JAVA_VERSION-linux-x64.tar.gz" | tar -zx -C /opt/ && \
     apt-get -y autoremove \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* && \

--- a/recipes/debian_jre/Dockerfile
+++ b/recipes/debian_jre/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "deb http://ftp.debian.org/debian testing main" >> /etc/apt/sources.lis
     openssh-server \
     sudo \
     procps \
-    openjdk-8-jre \
+    openjdk-8-jre-headless \
     wget \
     unzip \
     mc \

--- a/recipes/hadoop-dev/Dockerfile
+++ b/recipes/hadoop-dev/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git -y && \
-    sudo apt-get install openjdk-8-jdk -y && \
+    sudo apt-get install openjdk-8-jdk-headless -y && \
     sudo update-ca-certificates -f && \
     sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get clean && \

--- a/recipes/hadoop-dev/Dockerfile
+++ b/recipes/hadoop-dev/Dockerfile
@@ -19,8 +19,12 @@ RUN apt-get update && \
     useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
     echo "secret\nsecret" | passwd user && \
     add-apt-repository ppa:git-core/ppa && \
+    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git -y && \
+    sudo apt-get install openjdk-8-jdk -y && \
+    sudo update-ca-certificates -f && \
+    sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -30,23 +34,15 @@ USER user
 LABEL che:server:8080:ref=tomcat8 che:server:8080:protocol=http che:server:8000:ref=tomcat8-debug che:server:8000:protocol=http che:server:9876:ref=codeserver che:server:9876:protocol=http
 
 ENV MAVEN_VERSION=3.3.9 \
-    JAVA_VERSION=8u45 \
-    JAVA_VERSION_PREFIX=1.8.0_45 \
+    JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 \
     TOMCAT_HOME=/home/user/tomcat8
 
-ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX \
-M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
+ENV M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
 
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
 RUN mkdir /home/user/cbuild /home/user/tomcat8 /home/user/apache-maven-$MAVEN_VERSION && \
-  wget \
-  --no-cookies \
-  --no-check-certificate \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-  -qO- \
-  "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b14/jdk-$JAVA_VERSION-linux-x64.tar.gz" | sudo tar -zx -C /opt/ && \
-  wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
+    wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
 ENV TERM xterm
 
 RUN wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \

--- a/recipes/selenium/Dockerfile
+++ b/recipes/selenium/Dockerfile
@@ -37,7 +37,7 @@ RUN sudo apt-get update -qqy && \
   x11vnc \
   xvfb \
   subversion \
-  openjdk-8-jdk \
+  openjdk-8-jdk-headless \
   net-tools \
   blackbox \
   rxvt-unicode \

--- a/recipes/selenium/Dockerfile
+++ b/recipes/selenium/Dockerfile
@@ -10,9 +10,10 @@ FROM ubuntu
 
 EXPOSE 8080 8000
 RUN apt-get update && \
-    apt-get -y install sudo procps wget unzip mc curl && \
+    apt-get -y install sudo procps wget unzip mc curl software-properties-common && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    add-apt-repository ppa:openjdk-r/ppa && \
     echo "secret\nsecret" | passwd user
 
 # install xserver, blackbox, Chrome, Selenium webdriver
@@ -36,10 +37,13 @@ RUN sudo apt-get update -qqy && \
   x11vnc \
   xvfb \
   subversion \
+  openjdk-8-jdk \
   net-tools \
   blackbox \
   rxvt-unicode \
   xfonts-terminus && \
+  sudo update-ca-certificates -f && \
+  sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
   sudo rm /etc/apt/sources.list.d/google-chrome.list \
   sudo rm -rf /var/lib/apt/lists/*
 
@@ -63,19 +67,13 @@ ENV MAVEN_VERSION=3.3.9 \
     JAVA_VERSION_PREFIX=1.8.0_45 \
     TOMCAT_HOME=/home/user/tomcat8
 
-ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX \
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 \
 M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
 
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
 RUN mkdir /home/user/cbuild /home/user/tomcat8 /home/user/apache-maven-$MAVEN_VERSION && \
-  wget \
-  --no-cookies \
-  --no-check-certificate \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-  -qO- \
-  "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b14/jdk-$JAVA_VERSION-linux-x64.tar.gz" | sudo tar -zx -C /opt/ && \
-  wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
+    wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
 ENV TERM xterm
 
 RUN wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \

--- a/recipes/ubuntu_android/Dockerfile
+++ b/recipes/ubuntu_android/Dockerfile
@@ -9,10 +9,8 @@
 FROM ubuntu:14.04
 
 ENV MAVEN_VERSION=3.3.9 \
-    JAVA_VERSION=8u45 \
-    JAVA_VERSION_PREFIX=1.8.0_45
-ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX \
-M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
+   JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
 ENV TERM xterm
 ENV LANG en_GB.UTF-8
 ENV LANG en_US.UTF-8
@@ -36,15 +34,13 @@ RUN sudo dpkg --add-architecture i386 && \
     sudo mkdir /var/run/sshd && \
     sudo sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     sudo add-apt-repository ppa:git-core/ppa && \
+    sudo add-apt-repository ppa:openjdk-r/ppa && \
     sudo apt-get update && \
     sudo sudo apt-get install git subversion -y && \
+    sudo apt-get install git -y && \
+    sudo apt-get install openjdk-8-jdk -y && \
+    sudo update-ca-certificates -f && \
     mkdir /home/user/apache-maven-$MAVEN_VERSION && \
-    wget \
-    --no-cookies \
-    --no-check-certificate \
-    --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-    -qO- \
-    "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b14/jdk-$JAVA_VERSION-linux-x64.tar.gz" | sudo tar -zx -C /opt/ && \
     wget -qO- "https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/ && \
     cd /home/user && wget --output-document=android-sdk.tgz --quiet http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz && tar -xvf android-sdk.tgz && rm android-sdk.tgz && \
     sudo apt-get clean && \

--- a/recipes/ubuntu_android/Dockerfile
+++ b/recipes/ubuntu_android/Dockerfile
@@ -38,7 +38,7 @@ RUN sudo dpkg --add-architecture i386 && \
     sudo apt-get update && \
     sudo sudo apt-get install git subversion -y && \
     sudo apt-get install git -y && \
-    sudo apt-get install openjdk-8-jdk -y && \
+    sudo apt-get install openjdk-8-jdk-headless -y && \
     sudo update-ca-certificates -f && \
     mkdir /home/user/apache-maven-$MAVEN_VERSION && \
     wget -qO- "https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/ && \

--- a/recipes/ubuntu_android/Dockerfile
+++ b/recipes/ubuntu_android/Dockerfile
@@ -38,7 +38,7 @@ RUN sudo dpkg --add-architecture i386 && \
     sudo apt-get update && \
     sudo sudo apt-get install git subversion -y && \
     sudo apt-get install git -y && \
-    sudo apt-get install openjdk-8-jdk-headless -y && \
+    sudo apt-get install openjdk-8-jdk -y && \
     sudo update-ca-certificates -f && \
     mkdir /home/user/apache-maven-$MAVEN_VERSION && \
     wget -qO- "https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/ && \

--- a/recipes/ubuntu_jdk8/Dockerfile
+++ b/recipes/ubuntu_jdk8/Dockerfile
@@ -8,8 +8,12 @@ RUN apt-get update && \
     useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
     echo "secret\nsecret" | passwd user && \
     add-apt-repository ppa:git-core/ppa && \
+    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git -y && \
+    sudo apt-get install openjdk-8-jdk -y && \
+    sudo update-ca-certificates -f && \
+    sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -20,23 +24,14 @@ LABEL che:server:8080:ref=tomcat8 che:server:8080:protocol=http che:server:8000:
 
 
 ENV MAVEN_VERSION=3.3.9 \
-    JAVA_VERSION=8u102 \
-    JAVA_BUILD=14 \
-    JAVA_VERSION_PREFIX=1.8.0_102 \
+    JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 \
     TOMCAT_HOME=/home/user/tomcat8 \
     TERM=xterm
-ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX
 ENV M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
 RUN mkdir /home/user/tomcat8 /home/user/apache-maven-$MAVEN_VERSION && \
-  wget \
-  --no-cookies \
-  --no-check-certificate \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-  -qO- \
-  "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b$JAVA_BUILD/jdk-$JAVA_VERSION-linux-x64.tar.gz" | sudo tar -zx -C /opt/
-RUN  wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/ && \
+    wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/ && \
     wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
     rm -rf /home/user/tomcat8/webapps/*
 

--- a/recipes/ubuntu_jdk8/Dockerfile
+++ b/recipes/ubuntu_jdk8/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git -y && \
-    sudo apt-get install openjdk-8-jdk -y && \
+    sudo apt-get install openjdk-8-jdk-headless -y && \
     sudo update-ca-certificates -f && \
     sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get clean && \

--- a/recipes/ubuntu_jre/Dockerfile
+++ b/recipes/ubuntu_jre/Dockerfile
@@ -8,10 +8,8 @@
 
 FROM ubuntu:14.04
 
-ENV JAVA_VERSION=8u65 \
-    JAVA_VERSION_PREFIX=1.8.0_65
-ENV JAVA_HOME /opt/jre$JAVA_VERSION_PREFIX
-ENV PATH $JAVA_HOME/bin:$PATH
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV PATH=$JAVA_HOME/bin:$PATH
 RUN apt-get update && \
     apt-get -y install \
     openssh-server \
@@ -30,18 +28,16 @@ RUN apt-get update && \
     useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
     echo "secret\nsecret" | passwd user && \
     add-apt-repository ppa:git-core/ppa && \
+    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git subversion -y && \
     apt-get clean && \
-    wget \
-   --no-cookies \
-   --no-check-certificate \
-   --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-   -qO- \
-   "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b17/jre-$JAVA_VERSION-linux-x64.tar.gz" | tar -zx -C /opt/ && \
-    apt-get -y autoremove \
-    && apt-get -y clean \
-    && rm -rf /var/lib/apt/lists/* && \
+    apt-get -y autoremove && \
+    sudo apt-get install openjdk-8-jdk -y && \
+    sudo update-ca-certificates -f && \
+    sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* && \
     echo "#! /bin/bash\n set -e\n sudo /usr/sbin/sshd -D &\n exec \"\$@\"" > /home/user/entrypoint.sh && chmod a+x /home/user/entrypoint.sh
 
 ENV LANG en_GB.UTF-8

--- a/recipes/ubuntu_jre/Dockerfile
+++ b/recipes/ubuntu_jre/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     sudo apt-get install git subversion -y && \
     apt-get clean && \
     apt-get -y autoremove && \
-    sudo apt-get install openjdk-8-jdk -y && \
+    sudo apt-get install openjdk-8-jre-headless -y && \
     sudo update-ca-certificates -f && \
     sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get -y clean && \

--- a/recipes/ubuntu_wildfly8/Dockerfile
+++ b/recipes/ubuntu_wildfly8/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git -y && \
-    sudo apt-get install openjdk-8-jdk -y && \
+    sudo apt-get install openjdk-8-jdk-headless -y && \
     sudo update-ca-certificates -f && \
     sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get clean && \

--- a/recipes/ubuntu_wildfly8/Dockerfile
+++ b/recipes/ubuntu_wildfly8/Dockerfile
@@ -16,8 +16,12 @@ RUN apt-get update && \
     useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
     echo "secret\nsecret" | passwd user && \
     add-apt-repository ppa:git-core/ppa && \
+    add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
     sudo apt-get install git -y && \
+    sudo apt-get install openjdk-8-jdk -y && \
+    sudo update-ca-certificates -f && \
+    sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -27,22 +31,14 @@ USER user
 LABEL che:server:8080:ref=wildfly che:server:9990:ref=jboss che:server:8080:protocol=http che:server:8000:ref=tomcat8-debug che:server:8000:protocol=http
 
 ENV MAVEN_VERSION=3.3.9 \
-    JAVA_VERSION=8u45 \
-    JAVA_VERSION_PREFIX=1.8.0_45 
 
-ENV JAVA_HOME=/opt/jdk$JAVA_VERSION_PREFIX \
-M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 \
+     M2_HOME=/home/user/apache-maven-$MAVEN_VERSION
 
 ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 
 RUN mkdir /home/user/apache-maven-$MAVEN_VERSION && \
-  wget \
-  --no-cookies \
-  --no-check-certificate \
-  --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-  -qO- \
-  "http://download.oracle.com/otn-pub/java/jdk/$JAVA_VERSION-b14/jdk-$JAVA_VERSION-linux-x64.tar.gz" | sudo tar -zx -C /opt/ && \
-  wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
+    wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
 ENV TERM xterm
 
 ENV WILDFLY_VERSION 8.2.0.Final


### PR DESCRIPTION
To improve licensing purity, predefined agent images now switched to OpenJDK.