### PR TITLE
Provide the M2_HOME environment variable

### DIFF
--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -12,7 +12,8 @@ ARG JAVA_VERSION=1.8.0
 ARG VERTX_VERSION=3.3.3
 
 ENV VERTX_GROUPID=io.vertx \
-    JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}
+    JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \
+    M2_HOME=/opt/rh/rh-maven33/root/usr/share/maven
 
 RUN yum -y update && \
     yum -y install sudo openssh-server centos-release-scl && \


### PR DESCRIPTION
It is is required by the Eclipse Che `MavenServerManager` component to
start the Maven server process.
see
https://github.com/eclipse/che/blob/master/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/MavenServerManager.java#L98

Signed-off-by: David Festal <dfestal@redhat.com>