### PR TITLE
Update vert.x version to 3.4.0

### DIFF
--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.centos.org/centos/centos
 MAINTAINER Clement Escoffier
 
 ARG JAVA_VERSION=1.8.0
-ARG VERTX_VERSION=3.3.3
+ARG VERTX_VERSION=3.4.0
 
 ENV VERTX_GROUPID=io.vertx \
     JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \

--- a/recipes/centos_vertx/install-vertx-dependencies.sh
+++ b/recipes/centos_vertx/install-vertx-dependencies.sh
@@ -25,6 +25,7 @@ function install {
 echo -e "${BLUE}Installing Vert.x ${VERTX_VERSION} dependencies..."
 install $VERTX_GROUPID:vertx-core:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-web:$VERTX_VERSION
+install $VERTX_GROUPID:vertx-web-client:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-web-templ-handlebars:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-web-templ-jade:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-web-templ-mvel:$VERTX_VERSION
@@ -35,6 +36,7 @@ install $VERTX_GROUPID:vertx-jdbc-client:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-service-discovery:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-circuit-breaker:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-redis-client:$VERTX_VERSION
+install $VERTX_GROUPID:vertx-config:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-mongo-client:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-rx-java:$VERTX_VERSION
 install $VERTX_GROUPID:vertx-dropwizard-metrics:$VERTX_VERSION


### PR DESCRIPTION
### What does this PR do?

Update vert.x version to 3.4.0
Also declare two new modules to be pre-provisioned.

#### Changelog

Updated vert.x version to 3.4.0 in Che's dockerfile for vert.x
Added two new modules to be pre-provisioned in Che's dockerfile for vert.x

#### Release Notes

Updated vert.x version to 3.4.0 and added two new modules in Che's dockerfile for vert.x

#### Docs PR
No change to docs.