### PR TITLE
Mysql image

### DIFF
--- a/recipes/mysql/Dockerfile
+++ b/recipes/mysql/Dockerfile
@@ -1,2 +1,4 @@
 FROM mysql:5.7
-RUN apt-get update && apt-get install curl rsync -y
+RUN apt-get update && apt-get install curl rsync -y && apt-get -y clean
+
+

--- a/recipes/mysql/Dockerfile
+++ b/recipes/mysql/Dockerfile
@@ -1,0 +1,2 @@
+FROM mysql:5.7
+RUN apt-get update && apt-get install curl rsync -y


### PR DESCRIPTION
We need own image with MySQL - the one that has rsync and curl - so that Terminal agent starts right away.