### PR TITLE
Fix for https://issues.jboss.org/browse/CHE-215

### DIFF
--- a/recipes/centos_spring_boot/Dockerfile
+++ b/recipes/centos_spring_boot/Dockerfile
@@ -11,7 +11,9 @@ ARG JAVA_VERSION=1.8.0
 ARG SPRING_BOOT_VERSION=1.4.1.RELEASE
 ARG JUNIT_VERSION=4.12
 
-ENV SPRING_BOOT_GROUP=org.springframework.boot
+ENV SPRING_BOOT_GROUP=org.springframework.boot \
+    JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \
+    M2_HOME=/opt/rh/rh-maven33/root/usr/share/maven
 
 RUN yum -y update && \
     yum -y install sudo openssh-server centos-release-scl && \


### PR DESCRIPTION
`M2_HOME` and `JAVA_HOME` env variables were missing.

Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

it add required environment variables that were missing and prevent the Workspace Maven Server to start.

### What issues does this PR fix or reference?

It fixes issue https://issues.jboss.org/browse/CHE-215

### Previous behavior

The Maven server cannot be started, so that the Maven nature cannot be added when importing a maven Java project

### New behavior

With this PR the Maven server starts correctly, so that the Maven nature is added as expected when importing a Maven Java project

### Tests written?
No
