### PR TITLE
Make the Labels consistent with the default port names in Openshift

### DIFF
--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -20,7 +20,7 @@ RUN yum update -y && \
 
 USER user
 
-LABEL che:server:8080:ref=tomcat8 che:server:8080:protocol=http che:server:8000:ref=tomcat8-debug che:server:8000:protocol=http
+LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
 
 ENV MAVEN_VERSION=3.3.9
 


### PR DESCRIPTION

Signed-off-by: David Festal <dfestal@redhat.com>

### What does this PR do?

This PR fixes port names defined by image labels, to make them consistent with the default port names defined in [this file](https://github.com/eclipse/che/blob/openshift-connector/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/CheServicePorts.java)

### What issues does this PR fix or reference?

This fixes the issue eclipse/che#5182
