### PR TITLE
Ensure ~/.composer is writable to user in PHP stack

### DIFF
--- a/recipes/php/Dockerfile
+++ b/recipes/php/Dockerfile
@@ -48,7 +48,8 @@ RUN sudo wget http://repos.zend.com/zend-server/9.0.2/deb_apache2.4/pool/zend-se
     sudo sed -i 's/;opcache.enable=0/opcache.enable=0/g' /etc/php/7.0/apache2/php.ini
 
 RUN curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer && \
-    sudo composer global require bamarni/symfony-console-autocomplete && \
+    sudo chown -R user:user ~/.composer && \
+    composer global require bamarni/symfony-console-autocomplete && \
     ~/.composer/vendor/bamarni/symfony-console-autocomplete/symfony-autocomplete --shell bash composer | sudo tee /etc/bash_completion.d/composer && \
     sudo wget -qO /usr/local/bin/phpunit https://phar.phpunit.de/phpunit.phar && sudo chmod +x /usr/local/bin/phpunit && \
     echo -e "MySQL password: $CHE_MYSQL_PASSWORD" >> /home/user/.mysqlrc && \


### PR DESCRIPTION
Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>

### What does this PR do?

It ensures that when installing Composer in the PHP stack, the `~/.composer` folder is writable to the `user` user. This avoids some warnings and misbehavior of the Composer tool.

### What issues does this PR fix or reference?

N/A

### Previous behavior

Calling composer printed warning like:

```
Cannot create cache directory /home/user/.composer/cache/repo/https---packagist.org/, or directory is not writable. Proceeding without cache
Cannot create cache directory /home/user/.composer/cache/files/, or directory is not writable. Proceeding without cache
```

### New behavior

Composer won't print any warnings that its cache directory is not writable.

### Tests written?
No

### Docs updated?
No need to update any docs.
