### PR TITLE
update vert.x version to 3.4.2

### DIFF
--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.centos.org/centos/centos
 MAINTAINER Clement Escoffier
 
 ARG JAVA_VERSION=1.8.0
-ARG VERTX_VERSION=3.4.1
+ARG VERTX_VERSION=3.4.2
 
 ENV VERTX_GROUPID=io.vertx \
     JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \


### PR DESCRIPTION
Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>

### What does this PR do?

Update Eclipse vert.x to version 3.4.2.

### What issues does this PR fix or reference?

None.

### Previous behavior

It was using Eclipse vert.x 3.4.1

### New behavior

It uses Eclipse Vert.x 3.4.2
