### PR TITLE
Install NodeJS in the PHP stack

### DIFF
--- a/recipes/php/Dockerfile
+++ b/recipes/php/Dockerfile
@@ -67,6 +67,11 @@ RUN curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/
     sudo mysql -uroot -e "GRANT ALL PRIVILEGES ON *.* TO '$CHE_MYSQL_USER'@'%' IDENTIFIED BY '"$CHE_MYSQL_PASSWORD"'; FLUSH PRIVILEGES;" && \
     sudo mysql -uroot -e "CREATE DATABASE $CHE_MYSQL_DB;"
 
+# Install NodeJS to improve startup time when the JSON language server is enabled
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && \
+    sudo apt-get update && \
+    sudo apt-get install -y nodejs
+
 # label is used in Servers tab to display mapped port for Apache process on 80 port in the container
 LABEL che:server:80:ref=apache2 che:server:80:protocol=http
 


### PR DESCRIPTION
### What does this PR do?

Installs NodeJS as part of the docker recipe. This significantly improves the startup time if the JSON LS agent is enabled, which is the default for the PHP stack.

### What issues does this PR fix or reference?

N/A

### Previous behavior
NodeJS is installed each time a new PHP stack is created. This may take up to several minutes on system with slower network connection.

### New behavior
Startup time is improved as NodeJS is already available in the PHP docker image.

### Tests written?
No

### Docs updated?
No need to update any docs.