### PR TITLE
Use eclipse/debian_jdk8

### DIFF
--- a/recipes/dotnet_core/Dockerfile
+++ b/recipes/dotnet_core/Dockerfile
@@ -7,7 +7,7 @@
 # Abel García Dorta <mercuriete@gmail.com> 
 # Roger S <narayanroger@gmail.com>
 
-FROM eclipse/debian_jre
+FROM eclipse/debian_jdk8
 RUN sudo curl -L -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130 && \
     sudo apt-get update && \
     sudo apt-get -y install libunwind8 gettext && \


### PR DESCRIPTION
It may cause legal issues to distribute JRE in containers.

### What does this PR do?

Using debian/jdk8 as the FROM image instead of debian/jre.
 
### What issues does this PR fix or reference?

The [comment](https://github.com/eclipse/che-dockerfiles/pull/63#issuecomment-312195082) in #63.

### Previous behavior

Used debian/jre.

### New behavior

Use deian/jdk8.

### Tests written?
No

### Docs updated?
No need.
