### PR TITLE
Use eclipse/ubuntu_python:2.7.

### DIFF
--- a/recipes/platformio/Dockerfile
+++ b/recipes/platformio/Dockerfile
@@ -1,3 +1,3 @@
-FROM codenvy/ubuntu_python:2.7
+FROM eclipse/ubuntu_python:2.7
 RUN sudo apt-get update && sudo apt-get -y install python-pip
 RUN sudo pip install -U PlatformIO


### PR DESCRIPTION
 Instead of `codenvy/ubuntu_python:2.7`.

### What does this PR do?

Fix the base image.

### What issues does this PR fix or reference?
No.

### Previous behavior
Used codenvy/ubuntu_python:2.7

### New behavior

Using eclipse/ubuntu_python:2.7.

### Tests written?
No

### Docs updated?
No need.