### PR TITLE
Add SCL environment variables to user's bashrc

### DIFF
--- a/recipes/centos_nodejs/Dockerfile
+++ b/recipes/centos_nodejs/Dockerfile
@@ -21,7 +21,9 @@ RUN yum -y update && \
 RUN yum -y install rh-nodejs4 && \
     yum -y clean all && \
     scl enable rh-nodejs4 'npm install -g npm@latest' && \
-    scl enable rh-nodejs4 'npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp'
+    scl enable rh-nodejs4 'npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp' && \
+    cat /opt/rh/rh-nodejs4/enable >> /home/user/.bashrc
+
 
 EXPOSE 3000 5000 9000 8080
 

--- a/recipes/centos_spring_boot/Dockerfile
+++ b/recipes/centos_spring_boot/Dockerfile
@@ -24,7 +24,9 @@ RUN yum -y update && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers
+    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
+    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
+
 
 COPY install_spring_boot_dependencies.sh /tmp/
 
@@ -37,5 +39,7 @@ RUN scl enable rh-maven33 /tmp/install_spring_boot_dependencies.sh && \
     sudo rm -f /tmp/install_spring_boot_dependencies.sh
 
 EXPOSE 8080
+
+WORKDIR /projects
 
 CMD tail -f /dev/null

--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -24,7 +24,8 @@ RUN yum -y update && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers
+    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
+    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
 
 COPY install-vertx-dependencies.sh /tmp/
 RUN chown user:user /tmp/install-vertx-dependencies.sh && \
@@ -35,5 +36,7 @@ RUN scl enable rh-maven33 /tmp/install-vertx-dependencies.sh && \
     sudo rm -f /tmp/install-vertx-dependencies.sh
 
 EXPOSE 8080
+
+WORKDIR /projects
 
 CMD tail -f /dev/null

--- a/recipes/centos_wildfly_swarm/Dockerfile
+++ b/recipes/centos_wildfly_swarm/Dockerfile
@@ -23,7 +23,8 @@ RUN yum -y update && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers
+    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
+    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
 
 COPY install-swarm-dependencies.sh /tmp/
 RUN chown user:user /tmp/install-swarm-dependencies.sh && \
@@ -34,5 +35,7 @@ RUN scl enable rh-maven33 /tmp/install-swarm-dependencies.sh && \
     sudo rm -f /tmp/install-swarm-dependencies.sh
 
 EXPOSE 8080
+
+WORKDIR /projects
 
 CMD tail -f /dev/null


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <dshah@redhat.com>

### What does this PR do?
- This PR adds environment variables from SCL installations to `user`'s `bashrc` so that (s)he doesn't need to prepend commands with `scl enable <scl-name>`.
- Sets `/projects` as the `WORKDIR` so that `user` doesn't end up with being at `/` after starting a workspace.

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/147

### Previous behavior
User had to `scl enable <scl-name>` each time to execute `npm`, `mvn`, etc. commands in CentOS based stacks.

### New behavior
`npm`, `mvn`, etc. commands should work without enabling any SCL by `user`.

ping @l0rd @gorkem 