### PR TITLE
Add labels on OSIO stacks to fix preview URLs

### DIFF
--- a/recipes/centos_spring_boot/Dockerfile
+++ b/recipes/centos_spring_boot/Dockerfile
@@ -35,6 +35,8 @@ RUN chown user:user /tmp/install_spring_boot_dependencies.sh && \
 
 USER user
 
+LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
+
 RUN scl enable rh-maven33 /tmp/install_spring_boot_dependencies.sh && \
     sudo rm -f /tmp/install_spring_boot_dependencies.sh
 

--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -32,6 +32,8 @@ RUN chown user:user /tmp/install-vertx-dependencies.sh && \
 chmod a+x /tmp/install-vertx-dependencies.sh
 USER user
 
+LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
+
 RUN scl enable rh-maven33 /tmp/install-vertx-dependencies.sh && \
     sudo rm -f /tmp/install-vertx-dependencies.sh
 

--- a/recipes/centos_wildfly_swarm/Dockerfile
+++ b/recipes/centos_wildfly_swarm/Dockerfile
@@ -31,6 +31,8 @@ RUN chown user:user /tmp/install-swarm-dependencies.sh && \
     chmod a+x /tmp/install-swarm-dependencies.sh
 USER user
 
+LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
+
 RUN scl enable rh-maven33 /tmp/install-swarm-dependencies.sh && \
     sudo rm -f /tmp/install-swarm-dependencies.sh
 


### PR DESCRIPTION
### What does this PR do?
Add the following line to Dockerfiles of openshift.io stacks:
```
LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
```

### What issues does this PR fix or reference?
https://github.com/openshiftio/openshift.io/issues/381
https://github.com/redhat-developer/rh-che/issues/92

### Previous behavior
Preview URL for vert.x stack run command looked like: 
`http://server-8080-tcp-${WS-NAME}-${ID}.8a09.starter-us-east-2.openshiftapps.com/`

### New behavior
Preview URL for vert.x stack run command looks like: 
`http://tomcat-${WS-NAME}-${ID}.8a09.starter-us-east-2.openshiftapps.com/`
