### PR TITLE
Downgrade nodejs

### DIFF
--- a/recipes/node/Dockerfile
+++ b/recipes/node/Dockerfile
@@ -16,22 +16,7 @@ RUN sudo apt-get update && \
     sudo apt-get -y clean && \
     sudo rm -rf /var/lib/apt/lists/* 
 
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    56730D5401028683275BD23C23EFEFE93C4CFFFE \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
-
-RUN wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
+RUN wget -qO- https://deb.nodesource.com/setup_7.x | sudo -E bash -
 RUN sudo apt update && sudo apt -y install nodejs
 
 EXPOSE 1337 3000 4200 5000 9000 8003


### PR DESCRIPTION
### What does this PR do?

Fixes node js debugger since it does not attach when node is 8.x version

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/5779