### PR TITLE
Add missing CMD to centos_go Dockerfile

### DIFF
--- a/recipes/centos_go/Dockerfile
+++ b/recipes/centos_go/Dockerfile
@@ -26,3 +26,7 @@ RUN yum -y update && \
 USER user
 
 EXPOSE 8080
+
+CMD sudo /usr/bin/ssh-keygen -A && \
+    sudo /usr/sbin/sshd -D && \
+    tail -f /dev/null

--- a/recipes/centos_go/Dockerfile
+++ b/recipes/centos_go/Dockerfile
@@ -27,6 +27,4 @@ USER user
 
 EXPOSE 8080
 
-CMD sudo /usr/bin/ssh-keygen -A && \
-    sudo /usr/sbin/sshd -D && \
-    tail -f /dev/null
+CMD tail -f /dev/null

--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -42,6 +42,4 @@ RUN svn --version && \
     sed -i 's/# store-plaintext-passwords = no/store-plaintext-passwords = yes/g' /home/user/.subversion/servers
 WORKDIR /projects
 
-CMD sudo /usr/bin/ssh-keygen -A && \
-    sudo /usr/sbin/sshd -D && \
-    tail -f /dev/null
+CMD tail -f /dev/null


### PR DESCRIPTION
### What does this PR do?
Add the default command that was missing in the `centos_go` Dockerfile

### What issues does this PR fix or reference?
A container based on image registry.centos.org/che-stacks/centos-go would exit abruptly instead of continue running in the background.