### PR TITLE
Update .NET Core to 2.0 stable

### DIFF
--- a/recipes/dotnet_core/Dockerfile
+++ b/recipes/dotnet_core/Dockerfile
@@ -7,14 +7,15 @@
 # Codenvy, S.A. - initial API and implementation
 
 FROM eclipse/stack-base:ubuntu
-RUN sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet-release/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list' && \
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893 && \
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg && \
+    sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg && \
+    sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list' && \
     wget -qO- https://deb.nodesource.com/setup_7.x | sudo -E bash - && \
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb http://download.mono-project.com/repo/ubuntu beta-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-beta.list && \
     sudo apt-get update && \
     sudo apt-get install -y \
-    dotnet-sdk-2.0.0-preview2-006497 \
+    dotnet-sdk-2.0.0 \
     mono-devel \
     nodejs && \
     sudo apt-get -y clean && \


### PR DESCRIPTION
Signed-off-by: Roger <narayanroger@gmail.com>

### What does this PR do?
Updates .NET Core to the latest, **stable** version. The current dockerfile uses beta and old gpg keys.
### What issues does this PR fix or reference?

### Previous behavior
Installed gpg keys from the ubuntu keyserver and installed the .NET Core 2.0 beta.

### New behavior
Uses the latest gpg key and stable .NET Core 2.0 package, per https://www.microsoft.com/net/core#linuxubuntu .

CC: @eivantsov 