### PR TITLE
Cleanup CentOS stacks

### DIFF
--- a/recipes/centos_ceylon_nodejs_dart/Dockerfile
+++ b/recipes/centos_ceylon_nodejs_dart/Dockerfile
@@ -6,12 +6,12 @@
 # Contributors:
 # Red Hat, Inc. - initial implementation
 
-FROM eclipse/centos_jdk8
+FROM registry.centos.org/che-stacks/centos-jdk8
 
 # Install nodejs for ls agents
 RUN sudo yum update -y && \
     curl -sL https://rpm.nodesource.com/setup_6.x | sudo -E bash - && \
-    sudo yum install -y bzip2 tar curl nodejs && \
+    sudo yum install -y bzip2 tar nodejs && \
     sudo yum clean all && \
     sudo rm -rf /tmp/* /var/cache/yum && \
     sudo ln -s /usr/bin/node /usr/bin/nodejs
@@ -49,5 +49,3 @@ ENV PATH $PATH:$CEYLON_HOME/bin:$DART_HOME/bin
 
 RUN ceylon plugin install --force com.vasileff.ceylon.dart.cli/1.3.2-DP4 \
     && ceylon install-dart --out +USER
-
-    

--- a/recipes/centos_go/Dockerfile
+++ b/recipes/centos_go/Dockerfile
@@ -4,27 +4,17 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM registry.centos.org/centos/centos
-
-ARG JAVA_VERSION=1.8.0
-
-ENV GOPATH=/go \
-    PATH=$GOPATH/bin:/usr/local/go/bin:$PATH \
-    JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}
-
-RUN yum -y update && \
-    yum -y install sudo openssh-server g++ gcc glibc-devel make golang java-${JAVA_VERSION}-openjdk-devel && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    mkdir -p "$GOPATH/src" "$GOPATH/bin" && sudo chmod -R 777 "$GOPATH"
-
-USER user
-
+FROM registry.centos.org/che-stacks/centos-stack-base
 EXPOSE 8080
 
-CMD tail -f /dev/null
+ENV GOPATH=/go \
+    PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN sudo yum -y update && \
+    sudo yum -y install gcc-c++ \
+           gcc \
+           glibc-devel \
+           make \
+           golang && \
+    sudo yum clean all && \
+    sudo mkdir -p "$GOPATH/src" "$GOPATH/bin" && sudo chmod -R 777 "$GOPATH"

--- a/recipes/centos_jdk8/.cccp.yml
+++ b/recipes/centos_jdk8/.cccp.yml
@@ -10,4 +10,4 @@
 # user-defined tests. More information on cccp.yml file can be found on:
 # https://github.com/CentOS/container-index#the-cccpyml-file
 
-job-id: centos-git
+job-id: centos-jdk8

--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -6,40 +6,26 @@
 # Contributors:
 # Codenvy, S.A. - initial API and implementation
 
-FROM centos
-EXPOSE 4403 8080 8000 22
-RUN yum update -y && \
-    yum -y install sudo openssh-server procps wget unzip mc git curl subversion nmap java-1.8.0-openjdk-devel && \
-    mkdir /var/run/sshd && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers
+FROM registry.centos.org/che-stacks/centos-stack-base
+EXPOSE 4403 8080 8000 9876 22
 
-USER user
+LABEL che:server:8080:ref=tomcat8 che:server:8080:protocol=http che:server:8000:ref=tomcat8-debug che:server:8000:protocol=http che:server:9876:ref=codeserver che:server:9876:protocol=http
 
-LABEL che:server:8080:ref=tomcat che:server:8080:protocol=http che:server:8000:ref=tomcat-jpda che:server:8000:protocol=http
+ENV M2_HOME=/opt/rh/rh-maven33/root/usr/share/maven \
+    TOMCAT_HOME=/home/user/tomcat8 \
+    TERM=xterm
+ENV PATH=$M2_HOME/bin:$PATH
 
-ENV MAVEN_VERSION=3.3.9
+RUN sudo yum -y update && \
+    sudo yum -y install rh-maven33 && \
+    sudo yum clean all && \
+    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
 
-ENV M2_HOME=/home/user/apache-maven-$MAVEN_VERSION \
-    JAVA_HOME=/etc/alternatives/java_sdk \
-    TOMCAT_HOME=/home/user/tomcat8
-
-ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
 ENV MAVEN_OPTS=$JAVA_OPTS
-RUN mkdir /home/user/tomcat8 && mkdir /home/user/apache-maven-$MAVEN_VERSION && \
-  wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/
-ENV TERM xterm
 
-RUN wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
-    rm -rf /home/user/tomcat8/webapps/*
+RUN mkdir /home/user/tomcat8 && \
+    wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
+    rm -rf /home/user/tomcat8/webapps/* && \
+    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc
+
 ENV LANG C.UTF-8
-RUN svn --version && \
-    sed -i 's/# store-passwords = no/store-passwords = yes/g' /home/user/.subversion/servers && \
-    sed -i 's/# store-plaintext-passwords = no/store-plaintext-passwords = yes/g' /home/user/.subversion/servers
-WORKDIR /projects
-
-CMD tail -f /dev/null

--- a/recipes/centos_nodejs/Dockerfile
+++ b/recipes/centos_nodejs/Dockerfile
@@ -4,32 +4,16 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM registry.centos.org/centos/centos
+FROM registry.centos.org/che-stacks/centos-stack-base
 
 MAINTAINER Dharmit Shah <dshah@redhat.com>
 
-RUN yum -y update && \
-    yum -y install git sudo openssh-server centos-release-scl && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers
+EXPOSE 3000 5000 9000 8080
+LABEL che:server:3000:ref=nodejs-3000 che:server:3000:protocol=http che:server:5000:ref=nodejs-5000 che:server:5000:protocol=http che:server:9000:ref=nodejs-9000 che:server:9000:protocol=http che:server:8080:ref=nodejs-8080 che:server:8080:protocol=http
 
-RUN yum -y install rh-nodejs4 && \
-    yum -y clean all && \
+RUN sudo yum update && \
+    sudo yum -y install rh-nodejs4 && \
+    sudo yum -y clean all && \
     scl enable rh-nodejs4 'npm install -g npm@latest' && \
     scl enable rh-nodejs4 'npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp' && \
     cat /opt/rh/rh-nodejs4/enable >> /home/user/.bashrc
-
-LABEL che:server:3000:ref=nodejs-3000 che:server:3000:protocol=http che:server:5000:ref=nodejs-5000 che:server:5000:protocol=http che:server:9000:ref=nodejs-9000 che:server:9000:protocol=http che:server:8080:ref=nodejs-8080 che:server:8080:protocol=http
-
-EXPOSE 3000 5000 9000 8080
-
-WORKDIR /projects
-
-USER user
-
-CMD tail -f /dev/null

--- a/recipes/centos_python/2/Dockerfile
+++ b/recipes/centos_python/2/Dockerfile
@@ -4,32 +4,14 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM registry.centos.org/centos/centos
+FROM registry.centos.org/che-stacks/centos-stack-base
+EXPOSE 8080
 
 MAINTAINER Dharmit Shah <dshah@redhat.com>
 
-ARG JAVA_VERSION=1.8.0
-
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}
-
-RUN yum -y update && \
-    yum -y install sudo openssh-server g++ gcc glibc-devel make golang java-${JAVA_VERSION}-openjdk-devel && \
-    yum -y install epel-release && \ 
-    yum -y install python-pip && \
-    pip install --no-cache-dir virtualenv && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    mkdir /projects && chown -R user:user /projects
-
-EXPOSE 8080
-
-WORKDIR /projects
-
-USER user
-
-CMD tailf /dev/null
+RUN sudo yum -y update && \
+    sudo yum -y install epel-release \ 
+                        python-pip && \
+    sudo pip install --upgrade pip && \
+    sudo pip install --no-cache-dir virtualenv && \
+    sudo yum clean all

--- a/recipes/centos_python/3/Dockerfile
+++ b/recipes/centos_python/3/Dockerfile
@@ -4,31 +4,11 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM registry.centos.org/centos/centos
+FROM registry.centos.org/che-stacks/centos-stack-base
 
 MAINTAINER Dharmit Shah <dshah@redhat.com>
 
-ARG JAVA_VERSION=1.8.0
-
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}
-
-RUN yum -y update && \
-    yum -y install sudo openssh-server g++ gcc glibc-devel make golang java-${JAVA_VERSION}-openjdk-devel && \
-    yum -y install centos-release-scl && \
-    yum -y install rh-python35 && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    mkdir /projects && chown -R user:user /projects
-
-EXPOSE 8080 
-
-WORKDIR /projects
-
-USER user
-
-CMD tailf /dev/null
+RUN sudo yum -y update && \
+    sudo yum -y install centos-release-scl && \
+    sudo yum -y install rh-python35 && \
+    sudo yum clean all

--- a/recipes/centos_spring_boot/Dockerfile
+++ b/recipes/centos_spring_boot/Dockerfile
@@ -3,45 +3,20 @@
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
-FROM registry.centos.org/centos/centos
+FROM registry.centos.org/che-stacks/centos-jdk8
 
 MAINTAINER Gytis Trikleris
 
-ARG JAVA_VERSION=1.8.0
+EXPOSE 8080
+LABEL che:server:8080:ref=springboot che:server:8080:protocol=http
+
 ARG SPRING_BOOT_VERSION=1.4.1.RELEASE
 ARG JUNIT_VERSION=4.12
 
-ENV SPRING_BOOT_GROUP=org.springframework.boot \
-    JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \
-    M2_HOME=/opt/rh/rh-maven33/root/usr/share/maven
-
-RUN yum -y update && \
-    yum -y install sudo openssh-server centos-release-scl && \
-    yum -y install rh-maven33 java-${JAVA_VERSION}-openjdk-devel && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
-
+ENV SPRING_BOOT_GROUP=org.springframework.boot
 
 COPY install_spring_boot_dependencies.sh /tmp/
-
 RUN chown user:user /tmp/install_spring_boot_dependencies.sh && \
-    chmod a+x /tmp/install_spring_boot_dependencies.sh
-
-USER user
-
-LABEL che:server:8080:ref=springboot che:server:8080:protocol=http
-
-RUN scl enable rh-maven33 /tmp/install_spring_boot_dependencies.sh && \
+    chmod a+x /tmp/install_spring_boot_dependencies.sh && \
+    scl enable rh-maven33 /tmp/install_spring_boot_dependencies.sh && \
     sudo rm -f /tmp/install_spring_boot_dependencies.sh
-
-EXPOSE 8080
-
-WORKDIR /projects
-
-CMD tail -f /dev/null

--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -4,41 +4,19 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM registry.centos.org/centos/centos
+FROM registry.centos.org/che-stacks/centos-jdk8
+
+EXPOSE 8080
+LABEL che:server:8080:ref=vertx che:server:8080:protocol=http
 
 MAINTAINER Clement Escoffier
 
-ARG JAVA_VERSION=1.8.0
 ARG VERTX_VERSION=3.4.2
 
-ENV VERTX_GROUPID=io.vertx \
-    JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \
-    M2_HOME=/opt/rh/rh-maven33/root/usr/share/maven
-
-RUN yum -y update && \
-    yum -y install sudo openssh-server centos-release-scl && \
-    yum -y install rh-maven33 java-${JAVA_VERSION}-openjdk-devel && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
+ENV VERTX_GROUPID=io.vertx 
 
 COPY install-vertx-dependencies.sh /tmp/
-RUN chown user:user /tmp/install-vertx-dependencies.sh && \
-chmod a+x /tmp/install-vertx-dependencies.sh
-USER user
-
-LABEL che:server:8080:ref=vertx che:server:8080:protocol=http
-
-RUN scl enable rh-maven33 /tmp/install-vertx-dependencies.sh && \
+RUN sudo chown user:user /tmp/install-vertx-dependencies.sh && \
+    chmod +x /tmp/install-vertx-dependencies.sh && \
+    scl enable rh-maven33 /tmp/install-vertx-dependencies.sh && \
     sudo rm -f /tmp/install-vertx-dependencies.sh
-
-EXPOSE 8080
-
-WORKDIR /projects
-
-CMD tail -f /dev/null

--- a/recipes/centos_wildfly_swarm/Dockerfile
+++ b/recipes/centos_wildfly_swarm/Dockerfile
@@ -4,40 +4,17 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-FROM registry.centos.org/centos/centos
+FROM registry.centos.org/che-stacks/centos-jdk8
 
 MAINTAINER Dharmit Shah
 
-ARG JAVA_VERSION=1.8.0
-ARG SWARM_VERSION=2017.7.0
-
-ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION} \
-    M2_HOME=/opt/rh/rh-maven33/root/usr/share/maven
-
-RUN yum -y update && \
-    yum -y install wget sudo openssh-server centos-release-scl && \
-    yum -y install rh-maven33 java-${JAVA_VERSION}-openjdk-devel && \
-    yum clean all && \
-    sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
-    sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
-    echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
-    usermod -p "*" user && \
-    sed -i 's/requiretty/!requiretty/g' /etc/sudoers && \
-    cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
-
-COPY install-swarm-dependencies.sh /tmp/
-RUN chown user:user /tmp/install-swarm-dependencies.sh && \
-    chmod a+x /tmp/install-swarm-dependencies.sh
-USER user
-
+EXPOSE 8080
 LABEL che:server:8080:ref=wildfly che:server:8080:protocol=http
 
-RUN scl enable rh-maven33 /tmp/install-swarm-dependencies.sh && \
+ARG SWARM_VERSION=2017.7.0
+
+COPY install-swarm-dependencies.sh /tmp/
+RUN sudo chown user:user /tmp/install-swarm-dependencies.sh && \
+    chmod a+x /tmp/install-swarm-dependencies.sh && \
+    scl enable rh-maven33 /tmp/install-swarm-dependencies.sh && \
     sudo rm -f /tmp/install-swarm-dependencies.sh
-
-EXPOSE 8080
-
-WORKDIR /projects
-
-CMD tail -f /dev/null

--- a/recipes/stack-base/centos/.cccp.yml
+++ b/recipes/stack-base/centos/.cccp.yml
@@ -1,0 +1,13 @@
+# Copyright (c) 2012-2017 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# This is file is needed to include the project in the CentOS Container
+# Pipeline main index. It can be used to set the image name (using job-id), set
+# the test script and/or build script and whether to perform or skip the
+# user-defined tests. More information on cccp.yml file can be found on:
+# https://github.com/CentOS/container-index#the-cccpyml-file
+
+job-id: centos-stack-base

--- a/recipes/stack-base/centos/Dockerfile
+++ b/recipes/stack-base/centos/Dockerfile
@@ -8,8 +8,22 @@ FROM registry.centos.org/centos/centos
 
 MAINTAINER Dharmit Shah <dshah@redhat.com>
 
+ARG JAVA_VERSION=1.8.0
+
+ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 RUN yum -y update && \
-    yum -y install sudo openssh-server git && \
+    yum -y install \
+    sudo \
+    openssh-server \
+    git \
+    wget \
+    unzip \
+    mc \
+    bash-completion \
+    centos-release-scl \
+    java-${JAVA_VERSION}-openjdk-devel && \
     yum clean all && \
     sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
     sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
@@ -19,5 +33,7 @@ RUN yum -y update && \
     sed -i 's/requiretty/!requiretty/g' /etc/sudoers
 
 USER user
+
+WORKDIR /projects
 
 CMD tail -f /dev/null


### PR DESCRIPTION
Signed-off-by: Mario Loriedo <mloriedo@redhat.com>

### What does this PR do?
- Move `recipes/centos/` to `recipes/stack-base/centos/` and rename it `centos-stack-base` (was `centos-git` before)
- Use `centos-stack-base` as base image for all CentOS stacks
- Use `centos-jdk8` as base image for:
   - `centos_ceylon_nodejs_dart`
   - `centos_spring_boot`
   - `centos_vertx`
   - `centos_wildfly_swarm`

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/147
