### PR TITLE
Upgrade centos-nodejs stack to rh-nodej6

### DIFF
--- a/recipes/centos_nodejs/Dockerfile
+++ b/recipes/centos_nodejs/Dockerfile
@@ -8,12 +8,11 @@ FROM registry.centos.org/che-stacks/centos-stack-base
 
 MAINTAINER Dharmit Shah <dshah@redhat.com>
 
-EXPOSE 3000 5000 9000 8080
-LABEL che:server:3000:ref=nodejs-3000 che:server:3000:protocol=http che:server:5000:ref=nodejs-5000 che:server:5000:protocol=http che:server:9000:ref=nodejs-9000 che:server:9000:protocol=http che:server:8080:ref=nodejs-8080 che:server:8080:protocol=http
+EXPOSE 1337 3000 4200 5000 9000 8003
+LABEL che:server:8003:ref=angular che:server:8003:protocol=http che:server:3000:ref=node-3000 che:server:3000:protocol=http che:server:9000:ref=node-9000 che:server:9000:protocol=http
 
 RUN sudo yum update && \
-    sudo yum -y install rh-nodejs4 && \
+    sudo yum -y install rh-nodejs6 && \
     sudo yum -y clean all && \
-    scl enable rh-nodejs4 'npm install -g npm@latest' && \
-    scl enable rh-nodejs4 'npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp' && \
-    cat /opt/rh/rh-nodejs4/enable >> /home/user/.bashrc
+    sudo scl enable rh-nodejs6 'npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp' && \
+    cat /opt/rh/rh-nodejs6/enable >> /home/user/.bashrc


### PR DESCRIPTION
### What does this PR do?
Make some changes to stack centos-nodejs
- Upgraded nodejs to v6
- Removed instruction `npm install -g npm@latest`
- Make exposed ports consistent with the ubuntu based nodejs stack

### What issues does this PR fix or reference?
- The build of the stack centos-nodejs was failing

