### PR TITLE
Add debug port (5005) of vertx so it can be listed in the debugger view

### DIFF
--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -6,8 +6,8 @@
 
 FROM registry.centos.org/che-stacks/centos-jdk8
 
-EXPOSE 8080
-LABEL che:server:8080:ref=vertx che:server:8080:protocol=http
+EXPOSE 8080 5005
+LABEL che:server:8080:ref=vertx che:server:8080:protocol=http che:server:5005:ref=vertx-debug che:server:5005:protocol=http
 
 MAINTAINER Clement Escoffier
 


### PR DESCRIPTION
### What does this PR do?
- Add debug port (5005) of vertx so it can be listed in the debugger view

### What issues does this PR fix or reference?
- https://github.com/redhat-developer/rh-che/issues/293


Change-Id: Ibd8b2ea5cb13ba57218491b9def77909f414ff02
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

