### PR TITLE
Prefix commands with `sudo` to prevent `docker build` failures

### DIFF
--- a/recipes/centos_spring_boot/Dockerfile
+++ b/recipes/centos_spring_boot/Dockerfile
@@ -16,7 +16,7 @@ ARG JUNIT_VERSION=4.12
 ENV SPRING_BOOT_GROUP=org.springframework.boot
 
 COPY install_spring_boot_dependencies.sh /tmp/
-RUN chown user:user /tmp/install_spring_boot_dependencies.sh && \
-    chmod a+x /tmp/install_spring_boot_dependencies.sh && \
+RUN sudo chown user:user /tmp/install_spring_boot_dependencies.sh && \
+    sudo chmod a+x /tmp/install_spring_boot_dependencies.sh && \
     scl enable rh-maven33 /tmp/install_spring_boot_dependencies.sh && \
     sudo rm -f /tmp/install_spring_boot_dependencies.sh


### PR DESCRIPTION
Signed-off-by: Dharmit Shah <dshah@redhat.com>

### What does this PR do?
User `user` is unable to change ownership of files without `sudo`
privileges. Add `sudo` privileges to avert the issue.