### PR TITLE
Segregate `epel-release` and `python-pip` installations

### DIFF
--- a/recipes/centos_python/2/Dockerfile
+++ b/recipes/centos_python/2/Dockerfile
@@ -10,8 +10,8 @@ EXPOSE 8080
 MAINTAINER Dharmit Shah <dshah@redhat.com>
 
 RUN sudo yum -y update && \
-    sudo yum -y install epel-release \ 
-                        python-pip && \
+    sudo yum -y install epel-release && \
+    sudo yum -y install python-pip && \
     sudo pip install --upgrade pip && \
     sudo pip install --no-cache-dir virtualenv && \
     sudo yum clean all


### PR DESCRIPTION
`python-pip` won't install if it's in the same `yum install` command as
`epel-release`.

Signed-off-by: Dharmit Shah <dshah@redhat.com>

### What does this PR do?
Segregates installation of `epel-release` and `python-pip` into `yum install` commands of their own.