### PR TITLE
Fixing #138

### DIFF
--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -23,9 +23,14 @@ RUN sudo yum -y update && \
 
 ENV MAVEN_OPTS=$JAVA_OPTS
 
-RUN mkdir /home/user/tomcat8 && \
+USER user
+
+RUN mkdir $HOME/.m2 && \
+    mkdir /home/user/tomcat8 && \
     wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
     rm -rf /home/user/tomcat8/webapps/* && \
     echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc
+
+ADD ./contrib/settings.xml $HOME/.m2/settings.xml
 
 ENV LANG C.UTF-8

--- a/recipes/centos_jdk8/contrib/settings.xml
+++ b/recipes/centos_jdk8/contrib/settings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+ <mirrors>
+   <!-- ### configured mirrors ### -->
+ </mirrors>
+
+ <proxies>
+   <!-- ### configured http proxy ### -->
+  </proxies>
+
+  <profiles>
+    <!-- Override the repository "central" from the Maven Super POM, to set HTTPS by default -->
+    <profile>
+      <id>securecentral</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>securecentral</activeProfile>
+  </activeProfiles>
+</settings>

--- a/recipes/centos_spring_boot/Dockerfile
+++ b/recipes/centos_spring_boot/Dockerfile
@@ -8,7 +8,7 @@ FROM registry.centos.org/che-stacks/centos-jdk8
 MAINTAINER Gytis Trikleris
 
 EXPOSE 8080
-LABEL che:server:8080:ref=springboot che:server:8080:protocol=http
+LABEL che:server:8080:ref=springboot che:server:8080:protocol=http 
 
 ARG SPRING_BOOT_VERSION=1.4.1.RELEASE
 ARG JUNIT_VERSION=4.12


### PR DESCRIPTION

Add settings.xml from contrib/settings.xml directory

Signed-off-by: Kamesh Sampath <kamesh.sampath@hotmail.com>

### What does this PR do?
This will add default settings.xml to $HOME/.m2/settings.xml, with placeholder for setting
maven mirrors(Issue #139) and http proxies that can be used by maven

### What issues does this PR fix or reference?
#138 

### Previous behavior

there was no maven settings.xml hence configuring of repositories, mirrors typically the  setttings that goes in to maven settings.xml was not possible 

### New behavior
Ability to add default maven settings.xml to $HOME/.m2 to enable maven settings cutomization

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No

### Docs updated?
N.A
