### PR TITLE
Fix permissions for server dirs

### DIFF
--- a/recipes/ubuntu_jdk8/Dockerfile
+++ b/recipes/ubuntu_jdk8/Dockerfile
@@ -14,4 +14,6 @@ RUN mkdir /home/user/tomcat8 /home/user/apache-maven-$MAVEN_VERSION && \
     wget -qO- "http://apache.ip-connect.vn.ua/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" | tar -zx --strip-components=1 -C /home/user/apache-maven-$MAVEN_VERSION/ && \
     wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
     rm -rf /home/user/tomcat8/webapps/* && \
-    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc
+    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc && \
+    sudo chgrp -R 0 ~/tomcat8 && \
+    sudo chmod -R g+rwX ~/tomcat8

--- a/recipes/ubuntu_wildfly8/Dockerfile
+++ b/recipes/ubuntu_wildfly8/Dockerfile
@@ -26,9 +26,11 @@ ENV WILDFLY_SHA1 c0dd7552c5207b0d116a9c25eb94d10b4f375549
 
 # Add the WildFly distribution to /opt, and make wildfly the owner of the extracted tar content
 # Make sure the distribution is available from a well-known place
-RUN cd /home/user \   
+RUN cd /home/user \
     && curl -O https://download.jboss.org/wildfly/$WILDFLY_VERSION/wildfly-$WILDFLY_VERSION.tar.gz && \
     tar xf wildfly-$WILDFLY_VERSION.tar.gz \
     && rm wildfly-$WILDFLY_VERSION.tar.gz && \
     sed -i 's/127.0.0.1/0.0.0.0/g' /home/user/wildfly-$WILDFLY_VERSION/standalone/configuration/standalone.xml && \
-    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc
+    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc && \
+   sudo chgrp -R 0 /home/user/wildfly-$WILDFLY_VERSION && \
+   sudo chmod -R g+rwX /home/user/wildfly-$WILDFLY_VERSION


### PR DESCRIPTION
### What does this PR do?

Fixes permissions for directories created in `/home/user` so that the images are compatible with OpenShift. Without this fix it is impossible to copy build artifacts to app server dirs.