### PR TITLE
Fix for redhat-developer/rh-che#371

### DIFF
--- a/recipes/centos_nodejs/Dockerfile
+++ b/recipes/centos_nodejs/Dockerfile
@@ -14,5 +14,11 @@ LABEL che:server:8003:ref=angular che:server:8003:protocol=http che:server:3000:
 RUN sudo yum update -y && \
     sudo yum -y install rh-nodejs6 && \
     sudo yum -y clean all && \
+    sudo ln -s /opt/rh/rh-nodejs6/root/usr/bin/node /usr/local/bin/nodejs && \
     sudo scl enable rh-nodejs6 'npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp' && \
     cat /opt/rh/rh-nodejs6/enable >> /home/user/.bashrc
+
+ENV PATH=/opt/rh/rh-nodejs6/root/usr/bin${PATH:+:${PATH}}
+ENV LD_LIBRARY_PATH=/opt/rh/rh-nodejs6/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+ENV PYTHONPATH=/opt/rh/rh-nodejs6/root/usr/lib/python2.7/site-packages${PYTHONPATH:+:${PYTHONPATH}}
+ENV MANPATH=/opt/rh/rh-nodejs6/root/usr/share/man:$MANPATH


### PR DESCRIPTION
### What does this PR do?
rh-nodejs6 is now linked to nodejs and the proper env variables are set for redhat-developer/rh-che#371 and redhat-developer/rh-che#189
 
### What issues does this PR fix or reference?
redhat-developer/rh-che#371
redhat-developer/rh-che#189

### Previous behavior
node was dependent on scl enable rh-nodejs6 command

### New behavior
node is no longer dependent on scl enable rh-nodejs6 command

### Tests written?
No (However tested using steps in https://github.com/redhat-developer/rh-che/issues/149#issuecomment-341438399) 