### PR TITLE
Fix for redhat-developer/rh-che#337

### DIFF
--- a/recipes/stack-base/centos/entrypoint.sh
+++ b/recipes/stack-base/centos/entrypoint.sh
@@ -29,9 +29,11 @@ fi
 
 if test "${USER_ID}" = 0; then
     # current user is root
+    /usr/bin/ssh-keygen -A
     /usr/sbin/sshd -D &
 elif sudo -n true > /dev/null 2>&1; then
     # current user is a suoder
+    sudo /usr/bin/ssh-keygen -A
     sudo /usr/sbin/sshd -D &
 fi
 


### PR DESCRIPTION
Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>

### What does this PR do?
This fix will use /usr/bin/ssh-keygen -A to generate host-keys that do not exist in the centos base stack

### What issues does this PR fix or reference?
Fix for redhat-developer/rh-che#337

### Previous behavior
It would throw an error saying the host-keys were not found then exiting

### New behavior
Fixed centos base stack to generate host keys when they do not exist
