### PR TITLE
add bzip2 lib to python 2.7 image

### DIFF
--- a/recipes/ubuntu_python/2.7/Dockerfile
+++ b/recipes/ubuntu_python/2.7/Dockerfile
@@ -11,7 +11,7 @@ FROM eclipse/stack-base:ubuntu
 # remove several traces of debian python
 RUN sudo apt-get purge -y python.* && \
     sudo apt-get update && \
-    sudo apt-get install -y gcc make python-pip zlibc zlib1g zlib1g-dev libssl-dev
+    sudo apt-get install -y gcc make python-pip zlibc zlib1g zlib1g-dev libssl-dev bzip2
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.


### PR DESCRIPTION
### What does this PR do?
Adds bzip2 lib to Python 2.7 image

### What issues does this PR fix or reference?
#160 

### Previous behavior
`pip install Twisted` failed

### New behavior
`pip install Twisted` succeeds

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No

### Docs updated?
No
