### PR TITLE
updated node dockerfile to include yarn

### DIFF
--- a/recipes/node/Dockerfile
+++ b/recipes/node/Dockerfile
@@ -17,8 +17,12 @@ RUN sudo apt-get update && \
     sudo apt-get -y clean && \
     sudo rm -rf /var/lib/apt/lists/* 
 
-RUN wget -qO- https://deb.nodesource.com/setup_7.x | sudo -E bash -
-RUN sudo apt update && sudo apt -y install nodejs
+RUN wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
+RUN sudo apt update && sudo apt -y install nodejs yarn
 
 EXPOSE 1337 3000 4200 5000 9000 8003
 RUN sudo npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp


### PR DESCRIPTION
### What does this PR do?
Installs Yarn on along with the Node.js

### What issues does this PR fix or reference?
`yarn` is now included with `library/node` docker image. This is a very useful library for modern frontend related work and it makes sense to update eclipse/node image to include it too.

### Previous behavior
only `npm` was used to install libraries

### New behavior
`yarn` can be used to install JavaScript libraries

### Tests written?
No

### Docs updated?
no doc updates added