### PR TITLE
Update Eclipse Vert.x version to 3.5.2

### DIFF
--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -10,9 +10,7 @@ EXPOSE 8080 5005
 LABEL che:server:8080:ref=vertx che:server:8080:protocol=http che:server:5005:ref=vertx-debug che:server:5005:protocol=http
 
 ARG JAVA_VERSION=1.8.0
-ARG VERTX_VERSION=3.5.1
-
-ARG VERTX_VERSION=3.4.2
+ARG VERTX_VERSION=3.5.2
 
 ENV VERTX_GROUPID=io.vertx 
 


### PR DESCRIPTION


### What does this PR do?

This PR bumps the Eclipse Vert.x version to 3.5.2.


### Previous behavior

Uses Vert.x 3.5.1

### New behavior

Uses Vert.x 3.5.2
