### PR TITLE
Adding ubuntu + Pony lang support

### DIFF
--- a/recipes/ubuntu_pony/Dockerfile
+++ b/recipes/ubuntu_pony/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse/stack-base:ubuntu
+
+ENV PONY_PACKAGE_VERSION 0.1.3-0ppa1~xenial
+
+RUN sudo add-apt-repository ppa:ponylang/ponylang
+RUN sudo apt-get update
+RUN sudo apt-get install -y pony-stable=${PONY_PACKAGE_VERSION}
+
+EXPOSE 8080

--- a/recipes/unbuntu_pony/Dockerfile
+++ b/recipes/unbuntu_pony/Dockerfile
@@ -1,7 +1,0 @@
-FROM eclipse/stack-base:ubuntu
-
-RUN sudo add-apt-repository -y ppa:ponylang/ponylang
-RUN sudo apt-get update
-RUN sudo apt-get install -y ponyc
-
-EXPOSE 8080

--- a/recipes/unbuntu_pony/Dockerfile
+++ b/recipes/unbuntu_pony/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse/stack-base:ubuntu
+
+RUN sudo add-apt-repository -y ppa:ponylang/ponylang
+RUN sudo apt-get update
+RUN sudo apt-get install -y ponyc
+
+EXPOSE 8080


### PR DESCRIPTION
### What does this PR do?

This adds the latest stable pony lang compiler support as a docker image to be used in eclipse/che as a potential stack. Longer term, this container can provide a pony agent for a save action compilation among other things, but shipping the compiler in the environment is a huge first step.

### What issues does this PR fix or reference?
NA

### Previous behavior
You would have to specify the pony lang support directly in the editor.

### New behavior
Pony lang support by default.

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No

### Docs updated?

> Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time.

^^ I would be more than happy doing this, but before I go down that road I was curious if this is something that would be supported.
