### PR TITLE
Fix permissions for Dart

### DIFF
--- a/recipes/centos_ceylon_nodejs_dart/Dockerfile
+++ b/recipes/centos_ceylon_nodejs_dart/Dockerfile
@@ -48,4 +48,6 @@ RUN echo "downloading Dart distribution ..." \
 ENV PATH $PATH:$CEYLON_HOME/bin:$DART_HOME/bin
 
 RUN ceylon plugin install --force com.vasileff.ceylon.dart.cli/1.3.2-DP4 \
-    && ceylon install-dart --out +USER
+    && ceylon install-dart --out +USER && \
+    sudo chgrp -R 0 ${HOME}/dart && \
+    sudo chmod -R g+rwX ${HOME}/dart


### PR DESCRIPTION
### What does this PR do?

Dart binary is unavailable because of wrong permissions. 