### PR TITLE
CDK-305 Adding user to the 'root' group as a workaround for unwritable pvs owned by root on minishift / origin

### DIFF
--- a/recipes/stack-base/centos/Dockerfile
+++ b/recipes/stack-base/centos/Dockerfile
@@ -30,7 +30,8 @@ RUN yum -y update && \
     sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
     sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
+    # Adding user to the 'root' is a workaround for https://issues.jboss.org/browse/CDK-305
+    useradd -u 1000 -G users,wheel,root -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
     sed -i 's/requiretty/!requiretty/g' /etc/sudoers
 

--- a/recipes/stack-base/debian/Dockerfile
+++ b/recipes/stack-base/debian/Dockerfile
@@ -29,7 +29,8 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/s
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    # Adding user to the 'root' is a workaround for https://issues.jboss.org/browse/CDK-305
+    useradd -u 1000 -G users,sudo,root -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
     sudo echo -e "deb http://ppa.launchpad.net/git-core/ppa/ubuntu precise main\ndeb-src http://ppa.launchpad.net/git-core/ppa/ubuntu precise main" >> /etc/apt/sources.list.d/sources.list && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \

--- a/recipes/stack-base/ubuntu/Dockerfile
+++ b/recipes/stack-base/ubuntu/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && \
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    # Adding user to the 'root' is a workaround for https://issues.jboss.org/browse/CDK-305
+    useradd -u 1000 -G users,sudo,root -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
     add-apt-repository ppa:git-core/ppa && \
     add-apt-repository ppa:openjdk-r/ppa && \


### PR DESCRIPTION
### What does this PR do?
Adding user to the 'root' group as a workaround for unwritable pvs owned by root on minishift / origin

![image](https://user-images.githubusercontent.com/1461122/42235208-5d9b584e-7ef7-11e8-918a-cd5c052c4e8a.png)


Details in https://issues.jboss.org/browse/CDK-305?focusedCommentId=13600344&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13600344


### What issues does this PR fix or reference?
https://issues.jboss.org/browse/CDK-305

### Previous behavior
Not possible to create workspace on minishift / origin with `anyuid` enabled using any stack 

### New behavior
Workspace creation works fine on minishift / origin with `anyuid` enabled using any stack 

### Tests written?
No, before merging need to test more. currently tested only for `centos_jdk8` and it seems to work fine on minishift / osio - no side effects were spotted. Here is the image I used for testing on minishift / osio which works fine with anyuid enabled `ibuziuk/centos_jdk8:rootGroup` [1]

[1]  https://hub.docker.com/r/ibuziuk/centos_jdk8/tags/

### Docs updated?
No