### PR TITLE
Remove MAVEN_OPTS export in bashrc

### DIFF
--- a/recipes/centos_jdk8/Dockerfile
+++ b/recipes/centos_jdk8/Dockerfile
@@ -21,8 +21,6 @@ RUN sudo yum -y update && \
     sudo yum clean all && \
     cat /opt/rh/rh-maven33/enable >> /home/user/.bashrc
 
-ENV MAVEN_OPTS=$JAVA_OPTS
-
 USER user
 
 ADD ./contrib/run.sh $HOME/run.sh
@@ -31,7 +29,6 @@ RUN mkdir -p $HOME/.m2 && \
     mkdir /home/user/tomcat8 && \
     wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
     rm -rf /home/user/tomcat8/webapps/* && \
-    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc && \
     sudo chmod a+x $HOME/run.sh && \
     sudo mkdir -p /home/user/jdtls/data && \
     sudo chgrp -R 0 ${HOME} && \

--- a/recipes/debian_jdk8/Dockerfile
+++ b/recipes/debian_jdk8/Dockerfile
@@ -25,7 +25,6 @@ ENV TERM xterm
 
 RUN wget -qO- "http://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/apache-tomcat-8.0.24.tar.gz" | tar -zx --strip-components=1 -C /home/user/tomcat8 && \
     rm -rf /home/user/tomcat8/webapps/* && \
-    echo "export MAVEN_OPTS=\$JAVA_OPTS" >> /home/user/.bashrc && \
     sudo mkdir -p /home/user/.m2 && \
     sudo mkdir -p /home/user/jdtls/data && \
     sudo chown -R 0 /home/user && \


### PR DESCRIPTION
### What does this PR do?

Removes MAVEN_OPTS export in bashrc that removes inconsistency between running commands in a bash temrinal vs via k8s exec or exec agent/commands widget in che

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/9621
