### PR TITLE
Update alpine_jdk8 to use OpenJDK 8u171

### DIFF
--- a/recipes/alpine_jdk8/Dockerfile
+++ b/recipes/alpine_jdk8/Dockerfile
@@ -8,7 +8,7 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-FROM openjdk:8u111-jre-alpine
+FROM openjdk:8u171-jre-alpine
 
 ENV LANG=C.UTF-8 \
     DOCKER_VERSION=1.6.0 \
@@ -18,8 +18,7 @@ ENV LANG=C.UTF-8 \
 ENV M2_HOME=/usr/lib/apache-maven-$MAVEN_VERSION
 ENV PATH=${PATH}:${M2_HOME}/bin
 
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
-    apk add --update sudo curl ca-certificates bash openssh unzip openssl shadow && \
+RUN apk add --update sudo curl ca-certificates bash openssh unzip openssl shadow apk-tools && \
     curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
     cd /tmp && \


### PR DESCRIPTION
### What does this PR do?
Update alpine_jdk8 to use OpenJDK 8u171, removing unnecessary `edge` repository line (if `edge` repositories are to be used, they should replace the existing lines), adds `apk-tools` to update list, to avert `apk-tools IS OLD` warning.

### What issues does this PR fix or reference?
It updates the Alpine Linux to be on par with the other images.

### Tests written?
No

### Docs updated?
No
