### PR TITLE
Update .NET Core and Omnisharp

### DIFF
--- a/recipes/dotnet_core/Dockerfile
+++ b/recipes/dotnet_core/Dockerfile
@@ -9,8 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 
 FROM eclipse/stack-base:ubuntu
-ENV OMISHARP_VERSION="1.31.1"
-ENV OMNISHARP_DOWNLOAD_URL="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${OMISHARP_VERSION}/omnisharp-linux-x64.tar.gz"
+ENV OMNISHARP_VERSION="1.32.6"
+ENV OMNISHARP_DOWNLOAD_URL="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${OMNISHARP_VERSION}/omnisharp-linux-x64.tar.gz"
 ENV CSHARP_LS_DIR=${HOME}/che/ls-csharp
 RUN sudo apt-get update && sudo apt-get install apt-transport-https -y && \
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > ~/microsoft.gpg && \
@@ -19,7 +19,7 @@ RUN sudo apt-get update && sudo apt-get install apt-transport-https -y && \
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     sudo apt-get update && \
     sudo apt-get install -y \
-    dotnet-sdk-2.0.0 && \
+    dotnet-sdk-2.1 && \
     sudo apt-get -y clean && \
     sudo rm -rf /var/lib/apt/lists/* && \
     mkdir -p ${CSHARP_LS_DIR}


### PR DESCRIPTION
Signed-off-by: Roger <sachanroger@gmail.com>

### What does this PR do?
* Updates the .NET Core template from 2.0 to 2.1. .NET Core 2.0 hit [EOL](https://blogs.msdn.microsoft.com/dotnet/2018/06/20/net-core-2-0-will-reach-end-of-life-on-september-1-2018/) on October 1, 2018.
* Update omnisharp in the template to the latest version for .NET Core 2.1 support.

### New behavior
(Explain the PR as it should appear in the release notes)
Upgraded the .NET Core template to .NET Core 2.1
Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
No