### PR TITLE
Don't specify release versions of openjdk-8. (fixes #210)

### DIFF
--- a/recipes/stack-base/ubuntu/Dockerfile
+++ b/recipes/stack-base/ubuntu/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && \
     sudo apt-get install git subversion -y && \
     apt-get clean && \
     apt-get -y autoremove && \
-    sudo apt-get install openjdk-8-jdk-headless=8u171-b11-0ubuntu0.16.04.1 openjdk-8-source=8u171-b11-0ubuntu0.16.04.1 -y && \
+    sudo apt-get install openjdk-8-jdk-headless openjdk-8-source -y && \
     sudo update-ca-certificates -f && \
     sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get -y clean && \


### PR DESCRIPTION
### What does this PR do?

fixes #210 by removing explicit version specification.

### What issues does this PR fix or reference?

#210.

### Tests written?

No

### Docs updated?

No
