### PR TITLE
Use stable Yarnpkg installation method

### DIFF
--- a/recipes/node/Dockerfile
+++ b/recipes/node/Dockerfile
@@ -10,8 +10,12 @@
 
 FROM eclipse/stack-base:debian
 
+
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    
 RUN sudo apt-get update && \
-    sudo apt-get -y install build-essential libkrb5-dev gcc make ruby-full rubygems debian-keyring python2.7 && \
+    sudo apt-get -y install build-essential libkrb5-dev gcc make ruby-full rubygems debian-keyring python2.7 yarn && \
     sudo gem install --no-rdoc --no-ri sass -v 3.4.22 && \
     sudo gem install --no-rdoc --no-ri compass && \
     sudo apt-get clean && \
@@ -23,5 +27,5 @@ RUN wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
 RUN sudo apt update && sudo apt -y install nodejs
 
 EXPOSE 1337 3000 4200 5000 9000 8003
-RUN sudo npm install --unsafe-perm -g yarn gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp typescript typescript-language-server
+RUN sudo npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp typescript typescript-language-server
 LABEL che:server:8003:ref=angular che:server:8003:protocol=http che:server:3000:ref=node-3000 che:server:3000:protocol=http che:server:9000:ref=node-9000 che:server:9000:protocol=http


### PR DESCRIPTION
### What does this PR do?

NPM version is no longer supported. This installs it from yarnpkg's APT repositories.

### What issues does this PR fix or reference?

eclipse/che#12044

### Previous behavior

Acquires Yarn via NPM - which is marked outdated.

### New behavior

Yarn is now acquired using the APT repository - currently supported.
### Tests written?

No

### Docs updated?

No