### PR TITLE
update Vert.x version to 3.6.0

### DIFF
--- a/recipes/centos_vertx/Dockerfile
+++ b/recipes/centos_vertx/Dockerfile
@@ -14,7 +14,7 @@ EXPOSE 8080 5005
 LABEL che:server:8080:ref=vertx che:server:8080:protocol=http che:server:5005:ref=vertx-debug che:server:5005:protocol=http
 
 ARG JAVA_VERSION=1.8.0
-ARG VERTX_VERSION=3.5.2
+ARG VERTX_VERSION=3.6.0
 
 ENV VERTX_GROUPID=io.vertx 
 


### PR DESCRIPTION
### What does this PR do?

Update Vert.x version to 3.6.0.

### Previous behavior

The stack was using 3.5.2.

### New behavior

The stack is using 3.6.0

