### PR TITLE
 Fix build failure on centos_go image

### DIFF
--- a/recipes/centos_go/Dockerfile
+++ b/recipes/centos_go/Dockerfile
@@ -9,7 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 
 FROM registry.centos.org/che-stacks/centos-nodejs
-RUN sudo yum -y update && \
+RUN sudo yum -y install epel-release && \
+    sudo yum -y update && \
     sudo yum -y install gcc-c++ \
            gcc \
            glibc-devel \


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Install `epel-release`.

This is required to install `golang`.

### What issues does this PR fix or reference?

None

### Previous behavior

Builds are failed because `go` command wasn't installed.
The root cause is same as https://github.com/eclipse/che/pull/12343 https://github.com/eclipse/che/pull/12343/commits/8728c24157cd9e2f668ec390eb023a081c5bff3b

### New behavior

Builds successfully.

### Tests written?

No

### Docs updated?

No