### PR TITLE
che #13454 Support arbitrary user in che 7 images

### DIFF
--- a/recipes/che7/Dockerfile
+++ b/recipes/che7/Dockerfile
@@ -1,0 +1,9 @@
+ARG FROM_IMAGE
+FROM ${FROM_IMAGE}
+USER 0
+RUN chmod g=u /etc/passwd
+COPY [--chown=0:0] entrypoint.sh /
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+USER 10001
+WORKDIR /projects

--- a/recipes/che7/base_images
+++ b/recipes/che7/base_images
@@ -1,0 +1,8 @@
+dotnet mcr.microsoft.com/dotnet/core/sdk:2.2-stretch
+golang golang:1.12.4-stretch
+java11-maven maven:3.6.0-jdk-11
+java8-maven maven:3.6.1-jdk-8
+java-gradle gradle:5.2.1-jdk11
+node-alpine node:10.16-alpine
+node-ubi8 registry.access.redhat.com/ubi8/nodejs-10
+python-centos centos/python-36-centos7:1

--- a/recipes/che7/build_images.sh
+++ b/recipes/che7/build_images.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+REPOSITORY='eclipse-che'
+IMAGE_BASENAME='che7'
+
+while read -r line; do
+  tag=$(echo $line | cut -f 1 -d ' ')
+  image=$(echo $line | cut -f 2 -d ' ')
+  echo "Building ${REPOSITORY}/${IMAGE_BASENAME}-${tag} based on $image ..."
+  docker build -t "${REPOSITORY}/${IMAGE_BASENAME}-$tag" --build-arg FROM_IMAGE=$image .
+done < base_images

--- a/recipes/che7/entrypoint.sh
+++ b/recipes/che7/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
# What does this PR do?
Adding a set of Che 7 images based on the community images with the support of arbitrary user [1] to make them compatible with OpenShift:

````
if ! whoami &> /dev/null; then
  if [ -w /etc/passwd ]; then
    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
  fi
fi
````
[1] https://docs.okd.io/3.11/creating_images/guidelines.html#openshift-specific-guidelines

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13454