### PR TITLE
Add in PHP 7.4

### DIFF
--- a/recipes/php/7.4/Dockerfile
+++ b/recipes/php/7.4/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+FROM php:7.4-apache
+
+RUN apt-get -y update \
+    && apt-get install -y libicu-dev\
+    	tree \
+        vim \
+        wget \
+        git \
+        libzip-dev \
+        zlib1g-dev \
+        zip \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl \
+    && docker-php-ext-install zip mysqli pdo pdo_mysql \
+    && chmod -R 777 /etc/apache2  /var/www /var/lib/apache2 /var/log \
+    && chown -R www-data:www-data /var/www \
+    \
+    #change Apache configuration
+    \
+    && sed -i "s/80/8080/g" /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf \
+    && sed -i 's/\/var\/www\/html/\/projects/g'  /etc/apache2/sites-available/000-default.conf \
+    && sed -i 's/\/var\/www/\/projects/g'  /etc/apache2/apache2.conf \
+    && sed -i 's/None/All/g' /etc/apache2/sites-available/000-default.conf \
+    && echo "ServerName localhost" | tee -a /etc/apache2/apache2.conf
+
+#add composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /projects
+
+CMD sleep infinity


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR adapts the PHP 7.1 Dockerfile to PHP 7.4.

The only difference is that It removes the line `docker-php-ext-configure zip --with-libzip` to fix a build error that happens in 7.4 but not in 7.1. Apparently in [7.4 the defaults are sufficient](https://github.com/laradock/laradock/issues/2421#issuecomment-567728540).

This PR would supersede https://github.com/eclipse/che-dockerfiles/pull/252. (I'm trying to get this fix in before the next release of devfile registry) 

### What issues does this PR fix or reference?
Needed for https://github.com/eclipse/che/issues/15854

### Previous behavior
The previous behaviour is that you cannot run `install dependencies` because the PHP version is too old. You also cannot revert back to an earlier commit in the devfile because the of security issues that stop the build from finishing.

### New behavior
Once we update the PHP symphony devfile to use this new image then that devfile will work
