### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/recipes/cpp_gcc/Dockerfile
+++ b/recipes/cpp_gcc/Dockerfile
@@ -13,7 +13,7 @@ ENV CLANGD_VERSION="6.0"
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
     sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-${CLANGD_VERSION} main" && \
     sudo apt-get update && \
-    sudo apt-get install g++ gcc make gdb gdbserver clang-tools-${CLANGD_VERSION} -y && \
+    sudo apt-get --no-install-recommends -y -q install g++ gcc make gdb gdbserver clang-tools-${CLANGD_VERSION} -y && \
     sudo apt-get clean && \
     sudo apt-get -y autoremove && \
     sudo rm -rf /var/lib/apt/lists/* && \

--- a/recipes/debian_jdk8_node/Dockerfile
+++ b/recipes/debian_jdk8_node/Dockerfile
@@ -10,7 +10,7 @@
 
 FROM eclipse/debian_jdk8
 RUN sudo apt-get update && \
-    sudo apt-get -y install build-essential libkrb5-dev gcc make ruby-full rubygems debian-keyring python2.7 && \
+    sudo apt-get --no-install-recommends -y -q install build-essential libkrb5-dev gcc make ruby-full rubygems debian-keyring python2.7 && \
     sudo gem install --no-rdoc --no-ri sass -v 3.4.22 && \
     sudo gem install --no-rdoc --no-ri compass && \
     sudo apt-get clean && \
@@ -19,7 +19,7 @@ RUN sudo apt-get update && \
     sudo rm -rf /var/lib/apt/lists/*
 
 RUN wget -qO- https://deb.nodesource.com/setup_7.x | sudo -E bash -
-RUN sudo apt update && sudo apt -y install nodejs
+RUN sudo apt-get update && sudo apt-get -y install nodejs
 
 EXPOSE 1337 3000 4200 5000 9000 8003
 RUN sudo npm install --unsafe-perm -g gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp

--- a/recipes/dotnet_core/Dockerfile
+++ b/recipes/dotnet_core/Dockerfile
@@ -12,13 +12,13 @@ FROM eclipse/stack-base:ubuntu
 ENV OMISHARP_VERSION="1.31.1"
 ENV OMNISHARP_DOWNLOAD_URL="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v${OMISHARP_VERSION}/omnisharp-linux-x64.tar.gz"
 ENV CSHARP_LS_DIR=${HOME}/che/ls-csharp
-RUN sudo apt-get update && sudo apt-get install apt-transport-https -y && \
+RUN sudo apt-get update && sudo apt-get --no-install-recommends -y -q install apt-transport-https -y && \
     curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > ~/microsoft.gpg && \
     sudo mv ~/microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg && \
     sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list' && \
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     sudo apt-get update && \
-    sudo apt-get install -y \
+    sudo apt-get --no-install-recommends -y -q install \
     dotnet-sdk-2.0.0 && \
     sudo apt-get -y clean && \
     sudo rm -rf /var/lib/apt/lists/* && \

--- a/recipes/hadoop-dev/Dockerfile
+++ b/recipes/hadoop-dev/Dockerfile
@@ -17,4 +17,4 @@ RUN wget -O- http://archive.apache.org/dist/bigtop/bigtop-1.1.0/repos/GPG-KEY-bi
 RUN sudo wget -O /etc/apt/sources.list.d/bigtop-1.1.0.list \
 		http://archive.apache.org/dist/bigtop/bigtop-1.1.0/repos/trusty/bigtop.list
 RUN sudo apt-get update
-RUN sudo apt-get -y install hadoop-client hive pig sqoop flume 
+RUN sudo apt-get --no-install-recommends -y -q install hadoop-client hive pig sqoop flume 

--- a/recipes/meteor/Dockerfile
+++ b/recipes/meteor/Dockerfile
@@ -14,7 +14,7 @@ ENV NODE_VERSION 7.7.3
 ENV LC_ALL=POSIX
 
 RUN sudo apt-get update && \
-    sudo apt-get -y install locales build-essential libssl-dev libkrb5-dev gcc make ruby-full rubygems-integration && \
+    sudo apt-get --no-install-recommends -y -q install locales build-essential libssl-dev libkrb5-dev gcc make ruby-full rubygems-integration && \
     sudo gem install sass compass && \
     sudo apt-get clean && \
     sudo apt-get -y autoremove && \

--- a/recipes/mysql/Dockerfile
+++ b/recipes/mysql/Dockerfile
@@ -1,2 +1,2 @@
 FROM mysql:5.7
-RUN apt-get update && apt-get install curl rsync -y && apt-get -y clean
+RUN apt-get update && apt-get --no-install-recommends -y -q install curl rsync -y && apt-get -y clean

--- a/recipes/node/Dockerfile
+++ b/recipes/node/Dockerfile
@@ -11,7 +11,7 @@
 FROM eclipse/stack-base:debian
 
 RUN sudo apt-get update && \
-    sudo apt-get -y install build-essential libkrb5-dev gcc make ruby-full rubygems debian-keyring python2.7 && \
+    sudo apt-get --no-install-recommends -y -q install build-essential libkrb5-dev gcc make ruby-full rubygems debian-keyring python2.7 && \
     sudo gem install --no-rdoc --no-ri sass -v 3.4.22 && \
     sudo gem install --no-rdoc --no-ri compass && \
     sudo apt-get clean && \
@@ -20,7 +20,7 @@ RUN sudo apt-get update && \
     sudo rm -rf /var/lib/apt/lists/*
 
 RUN wget -qO- https://deb.nodesource.com/setup_8.x | sudo -E bash -
-RUN sudo apt update && sudo apt -y install nodejs
+RUN sudo apt-get update && sudo apt-get -y install nodejs
 
 EXPOSE 1337 3000 4200 5000 9000 8003
 RUN sudo npm install --unsafe-perm -g yarn gulp bower grunt grunt-cli yeoman-generator yo generator-angular generator-karma generator-webapp typescript typescript-language-server

--- a/recipes/php/7.1/Dockerfile
+++ b/recipes/php/7.1/Dockerfile
@@ -11,7 +11,7 @@
 FROM php:7.1-apache
 
 RUN apt-get -y update \
-    && apt-get install -y libicu-dev\
+    && apt-get --no-install-recommends -y -q install libicu-dev\
     	tree \
         vim \
         wget \

--- a/recipes/php/7.4/Dockerfile
+++ b/recipes/php/7.4/Dockerfile
@@ -11,7 +11,7 @@
 FROM php:7.4-apache
 
 RUN apt-get -y update \
-    && apt-get install -y libicu-dev\
+    && apt-get --no-install-recommends -y -q install libicu-dev\
     	tree \
         vim \
         wget \

--- a/recipes/php/Dockerfile
+++ b/recipes/php/Dockerfile
@@ -17,7 +17,7 @@ ENV CHE_MYSQL_USER=che
 ENV PHP_LS_VERSION=5.4.1
 # install php with a set of most widely used extensions
 RUN sudo apt-get update && \
-    sudo apt-get install -y \
+    sudo apt-get --no-install-recommends -y -q install \
     apache2 \
     php \
     php-mcrypt \
@@ -74,7 +74,7 @@ RUN curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/
 # Install NodeJS to improve startup time when the JSON language server is enabled
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && \
     sudo apt-get update && \
-    sudo apt-get install -y nodejs
+    sudo apt-get --no-install-recommends -y -q install nodejs
 
 # install language server
 
@@ -89,7 +89,7 @@ RUN mkdir -p ${HOME}/che/ls-php/php-language-server && \
     sudo chmod -R g+rwX ${HOME}/che
 ENV GAE_VERSION="1.9.70"
 RUN sudo apt-get update && \
-    sudo apt-get install --no-install-recommends -y -q build-essential python2.7 python2.7-dev python-pip php-bcmath && \
+    sudo apt-get --no-install-recommends -y -q install build-essential python2.7 python2.7-dev python-pip php-bcmath && \
     sudo pip install -U pip && \
     sudo pip install virtualenv
 RUN cd /home/user/ && wget -q https://storage.googleapis.com/appengine-sdks/featured/google_appengine_${GAE_VERSION}.zip && \

--- a/recipes/php/gae/Dockerfile
+++ b/recipes/php/gae/Dockerfile
@@ -12,7 +12,7 @@ FROM eclipse/php
 ENV GAE /home/user/google_appengine
 
 RUN sudo apt-get update && \
-    sudo apt-get install --no-install-recommends -y -q build-essential python2.7 python2.7-dev python-pip php-bcmath && \
+    sudo apt-get --no-install-recommends -y -q install build-essential python2.7 python2.7-dev python-pip php-bcmath && \
     sudo pip install -U pip && \
     sudo pip install virtualenv
 RUN cd /home/user/ && wget -q https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip && \

--- a/recipes/php/laravel/Dockerfile
+++ b/recipes/php/laravel/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse/php
 
 RUN sudo apt-get update && \
-    sudo apt-get install php7.0-zip -y && \
+    sudo apt-get --no-install-recommends -y -q install php7.0-zip -y && \
     sudo composer global require "laravel/installer" && \
     sudo apt-get -y clean && \
     sudo rm -rf /var/lib/apt/lists/*

--- a/recipes/platformio/Dockerfile
+++ b/recipes/platformio/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse/ubuntu_python:2.7
-RUN sudo apt-get update && sudo apt-get -y install python-pip
+RUN sudo apt-get update && sudo apt-get --no-install-recommends -y -q install python-pip
 RUN sudo pip install -U PlatformIO

--- a/recipes/ruby_rails/Dockerfile
+++ b/recipes/ruby_rails/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex \
 	ruby \
     ' \
     && sudo apt-get update \
-    && sudo apt-get install -y --no-install-recommends make gcc zlib1g-dev autoconf build-essential libssl-dev libsqlite3-dev $buildDeps tzdata \
+    && sudo apt-get --no-install-recommends -y -q install make gcc zlib1g-dev autoconf build-essential libssl-dev libsqlite3-dev $buildDeps tzdata \
     && sudo rm -rf /var/lib/apt/lists/* \
     && sudo curl -fSL -o ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
     && echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
@@ -70,10 +70,10 @@ ENV PATH $BUNDLE_BIN:$PATH
 RUN sudo mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
     && sudo chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
-RUN sudo apt-get update && sudo apt-get install -y nodejs --no-install-recommends && sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && sudo apt-get --no-install-recommends -y -q install nodejs --no-install-recommends && sudo rm -rf /var/lib/apt/lists/*
 
 # see http://guides.rubyonrails.org/command_line.html#rails-dbconsole
-RUN sudo apt-get update && sudo apt-get install -y mysql-client postgresql-client sqlite3 --no-install-recommends && sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get update && sudo apt-get --no-install-recommends -y -q install mysql-client postgresql-client sqlite3 --no-install-recommends && sudo rm -rf /var/lib/apt/lists/*
 
 RUN sudo gem install rails --version "$RAILS_VERSION"
 

--- a/recipes/stack-base/debian/Dockerfile
+++ b/recipes/stack-base/debian/Dockerfile
@@ -13,7 +13,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 ENV PATH $JAVA_HOME/bin:$PATH
 RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get -y install \
+    apt-get --no-install-recommends -y -q install \
     openssh-server \
     sudo \
     rsync \
@@ -36,7 +36,7 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/s
     usermod -p "*" user && \
     sudo echo -e "deb http://ppa.launchpad.net/git-core/ppa/ubuntu precise main\ndeb-src http://ppa.launchpad.net/git-core/ppa/ubuntu precise main" >> /etc/apt/sources.list.d/sources.list && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \
-    sudo apt-get install git subversion -y && \
+    sudo apt-get --no-install-recommends -y -q install git subversion -y && \
     apt-get clean && \
     apt-get -y autoremove \
     && apt-get -y clean \

--- a/recipes/stack-base/ubuntu/Dockerfile
+++ b/recipes/stack-base/ubuntu/Dockerfile
@@ -13,7 +13,7 @@ FROM ubuntu:16.04
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 ENV PATH=$JAVA_HOME/bin:$PATH
 RUN apt-get update && \
-    apt-get -y install \
+    apt-get --no-install-recommends -y -q install \
     locales \
     rsync \
     openssh-server \
@@ -36,10 +36,10 @@ RUN apt-get update && \
     add-apt-repository ppa:git-core/ppa && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get update && \
-    sudo apt-get install git subversion -y && \
+    sudo apt-get --no-install-recommends -y -q install git subversion -y && \
     apt-get clean && \
     apt-get -y autoremove && \
-    sudo apt-get install openjdk-8-jdk-headless=8u171-b11-0ubuntu0.16.04.1 openjdk-8-source=8u171-b11-0ubuntu0.16.04.1 -y && \
+    sudo apt-get --no-install-recommends -y -q install openjdk-8-jdk-headless=8u171-b11-0ubuntu0.16.04.1 openjdk-8-source=8u171-b11-0ubuntu0.16.04.1 -y && \
     sudo update-ca-certificates -f && \
     sudo sudo /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     apt-get -y clean && \

--- a/recipes/ubuntu_go/Dockerfile
+++ b/recipes/ubuntu_go/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse/stack-base:ubuntu
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash - && \
-    sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    sudo apt-get update && sudo apt-get --no-install-recommends -y -q install \
     g++ \
     gcc \
     libc6-dev \

--- a/recipes/ubuntu_python/2.7/Dockerfile
+++ b/recipes/ubuntu_python/2.7/Dockerfile
@@ -13,7 +13,7 @@ FROM eclipse/stack-base:ubuntu
 # remove several traces of debian python
 RUN sudo apt-get purge -y python.* && \
     sudo apt-get update && \
-    sudo apt-get install -y gcc make python-pip zlibc zlib1g zlib1g-dev libssl-dev
+    sudo apt-get --no-install-recommends -y -q install gcc make python-pip zlibc zlib1g zlib1g-dev libssl-dev
 
 # http://bugs.python.org/issue19846
 # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.

--- a/recipes/ubuntu_python/Dockerfile
+++ b/recipes/ubuntu_python/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse/stack-base:ubuntu
-RUN sudo apt-get purge -y python.* &&   sudo apt-get update &&   sudo apt-get install -y --no-install-recommends \
+RUN sudo apt-get purge -y python.* &&   sudo apt-get update &&   sudo apt-get --no-install-recommends -y -q install \
     autoconf \
     automake \
     bzip2 \

--- a/recipes/ubuntu_python/gae_python2.7/Dockerfile
+++ b/recipes/ubuntu_python/gae_python2.7/Dockerfile
@@ -13,7 +13,7 @@ FROM eclipse/stack-base:debian
 ENV GAE /home/user/google_appengine
 
 RUN sudo apt-get update && \
-    sudo apt-get install --no-install-recommends -y -q build-essential python2.7 python2.7-dev python-pip && \
+    sudo apt-get --no-install-recommends -y -q install build-essential python2.7 python2.7-dev python-pip && \
     sudo pip install -U pip && \
     sudo pip install virtualenv
 RUN wget -qO- "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip" -O /tmp/gae-sdk.zip && \

--- a/recipes/ubuntu_python/gae_python3/Dockerfile
+++ b/recipes/ubuntu_python/gae_python3/Dockerfile
@@ -13,7 +13,7 @@ FROM eclipse/stack-base:debian
 ENV GAE /home/user/google_appengine
 
 RUN sudo apt-get update -y && \
-    sudo apt-get install --no-install-recommends -y -q build-essential python3 python3-dev python-pip git python3-pip && \
+    sudo apt-get --no-install-recommends -y -q install build-essential python3 python3-dev python-pip git python3-pip && \
     sudo pip3 install -U pip && \
     sudo pip3 install virtualenv
 RUN wget -qO- "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip" -O /tmp/gae-sdk.zip && \

--- a/recipes/ubuntu_rlang/Dockerfile
+++ b/recipes/ubuntu_rlang/Dockerfile
@@ -10,11 +10,11 @@
 FROM eclipse/stack-base:ubuntu
 
 RUN sudo apt-get update && \
-    sudo apt-get -y install apt-transport-https build-essential libkrb5-dev gcc make debian-keyring python2.7 && \
+    sudo apt-get --no-install-recommends -y -q install apt-transport-https build-essential libkrb5-dev gcc make debian-keyring python2.7 && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
     sudo add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu xenial/' && \
     sudo apt-get update && \
-    sudo apt-get install -y r-base
+    sudo apt-get --no-install-recommends -y -q install r-base
     
 EXPOSE 1337 3000 4200 5000 9000 8003
 LABEL che:server:8003:ref=angular che:server:8003:protocol=http che:server:3000:ref=node-3000 che:server:3000:protocol=http che:server:9000:ref=node-9000 che:server:9000:protocol=http    

--- a/recipes/x11_vnc/Dockerfile
+++ b/recipes/x11_vnc/Dockerfile
@@ -11,7 +11,7 @@
 FROM eclipse/ubuntu_jdk8
 
 RUN sudo apt-get update && \
-    sudo apt-get install -y --no-install-recommends supervisor x11vnc xvfb net-tools blackbox rxvt-unicode xfonts-terminus libxi6 libgconf-2-4
+    sudo apt-get --no-install-recommends -y -q install supervisor x11vnc xvfb net-tools blackbox rxvt-unicode xfonts-terminus libxi6 libgconf-2-4
 
 # download and install noVNC
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>