### PR TITLE
chore: use `--no-cache-dir` flag to `pip` in dockerfiles, to save space

### DIFF
--- a/recipes/php/Dockerfile
+++ b/recipes/php/Dockerfile
@@ -91,7 +91,7 @@ ENV GAE_VERSION="1.9.70"
 RUN sudo apt-get update && \
     sudo apt-get install --no-install-recommends -y -q build-essential python2.7 python2.7-dev python-pip php-bcmath && \
     sudo pip install -U pip && \
-    sudo pip install virtualenv
+    sudo pip install --no-cache-dir virtualenv
 RUN cd /home/user/ && wget -q https://storage.googleapis.com/appengine-sdks/featured/google_appengine_${GAE_VERSION}.zip && \
     unzip -q google_appengine_${GAE_VERSION}.zip && \
     rm google_appengine_${GAE_VERSION}.zip && \

--- a/recipes/php/gae/Dockerfile
+++ b/recipes/php/gae/Dockerfile
@@ -14,7 +14,7 @@ ENV GAE /home/user/google_appengine
 RUN sudo apt-get update && \
     sudo apt-get install --no-install-recommends -y -q build-essential python2.7 python2.7-dev python-pip php-bcmath && \
     sudo pip install -U pip && \
-    sudo pip install virtualenv
+    sudo pip install --no-cache-dir virtualenv
 RUN cd /home/user/ && wget -q https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip && \
     unzip -q google_appengine_1.9.40.zip && \
     rm google_appengine_1.9.40.zip && \

--- a/recipes/platformio/Dockerfile
+++ b/recipes/platformio/Dockerfile
@@ -1,3 +1,3 @@
 FROM eclipse/ubuntu_python:2.7
 RUN sudo apt-get update && sudo apt-get -y install python-pip
-RUN sudo pip install -U PlatformIO
+RUN sudo pip install --no-cache-dir -U PlatformIO

--- a/recipes/ubuntu_python/Dockerfile
+++ b/recipes/ubuntu_python/Dockerfile
@@ -20,6 +20,6 @@ RUN set -ex && sudo curl -fSL "https://www.python.org/ftp/python/${PYTHON_VERSIO
 RUN cd /usr/local/bin && sudo ln -s easy_install-3.5 easy_install && sudo ln -s idle3 idle && sudo ln -s pydoc3 pydoc && sudo ln -s python3 python && sudo ln -s python-config3 python-config
 RUN sudo pip install --upgrade pip && \
     sudo pip install --no-cache-dir virtualenv && \
-    sudo pip install --upgrade setuptools && \
-    sudo pip install 'python-language-server[all]'
+    sudo pip install --no-cache-dir --upgrade setuptools && \
+    sudo pip install --no-cache-dir 'python-language-server[all]'
 EXPOSE 8080

--- a/recipes/ubuntu_python/gae_python2.7/Dockerfile
+++ b/recipes/ubuntu_python/gae_python2.7/Dockerfile
@@ -15,7 +15,7 @@ ENV GAE /home/user/google_appengine
 RUN sudo apt-get update && \
     sudo apt-get install --no-install-recommends -y -q build-essential python2.7 python2.7-dev python-pip && \
     sudo pip install -U pip && \
-    sudo pip install virtualenv
+    sudo pip install --no-cache-dir virtualenv
 RUN wget -qO- "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip" -O /tmp/gae-sdk.zip && \
     unzip -q /tmp/gae-sdk.zip -d /home/user && \
     rm /tmp/gae-sdk.zip

--- a/recipes/ubuntu_python/gae_python3/Dockerfile
+++ b/recipes/ubuntu_python/gae_python3/Dockerfile
@@ -15,7 +15,7 @@ ENV GAE /home/user/google_appengine
 RUN sudo apt-get update -y && \
     sudo apt-get install --no-install-recommends -y -q build-essential python3 python3-dev python-pip git python3-pip && \
     sudo pip3 install -U pip && \
-    sudo pip3 install virtualenv
+    sudo pip install --no-cache-dir virtualenv
 RUN wget -qO- "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip" -O /tmp/gae-sdk.zip && \
     unzip -q /tmp/gae-sdk.zip -d /home/user && \
     rm /tmp/gae-sdk.zip


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>